### PR TITLE
removed custom mypy

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,16 +33,6 @@ In the instructions below, replace ocio with your desired package to generate.
 
 First, look at `ocio/stubgen_ocio.sh` to see if there are any env vars to set in the `# Custom variables` section.
 
-Next, you'll need to check out a custom build of mypy (until my [PR](https://github.com/python/mypy/pull/15770) gets merged):
-
-```
-git clone https://github.com/LumaPictures/cg-stubs
-git clone https://github.com/chadrik/mypy
-cd mypy
-git checkout stubgen/shared-sig-gen-14
-cd ..
-```
-
 Next, build the stubs using [`nox`](https://nox.thea.codes/en/stable/index.html).  Requires python 3.7+:
 
 ```
@@ -56,10 +46,10 @@ nox -s 'generate(ocio)'
 If this fails, here's a more foolproof approach:
 
 ```
-# setup your env, e.g. setpkg python-3.7
+# setup your env, e.g. setpkg python-3.9
 unset PYTHONPATH
-python3 -m venv .venv37
-. .venv37/bin/activate
+python3 -m venv .venv39
+. .venv39/bin/activate
 python3 -m pip install -r nox-requirements.txt
 rm -rf .nox
 python3 -m nox -s 'generate(ocio)'
@@ -70,7 +60,7 @@ python3 -m nox -s 'generate(ocio)'
 The easiest way to use the stubs while you're devleoping them is to create an editable install.  Simply create a `.pth` file in the site-packages directory of the venv where your other deps live:
 
 ```
-echo "/path/to/cg-stubs/ocio/stubs/" > /path/to/venv/lib/python3.7/site-packages/ocio.pth
+echo "/path/to/cg-stubs/ocio/stubs/" > /path/to/venv/lib/python3.9/site-packages/ocio.pth
 ```
 
 The name of the .pth file does not matter.  Note that if you're using the mypy daemon, be sure to run `dmypy stop` to reread freshly modified stubs.
@@ -83,7 +73,7 @@ The USD stubs currently require you to build a special fork of USD, until the ne
 git clone https://github.com/chadrik/USD
 git checkout doc-stubs2
 python3 -m venv .venv
-.venv/bin/activate
+. .venv/bin/activate
 pip install PySide6 PyOpenGL
 python3 build_scripts/build_usd.py --python-docs --docs .build
 ```

--- a/houdini/stubgen_houdini.sh
+++ b/houdini/stubgen_houdini.sh
@@ -12,7 +12,7 @@ setpkg -c python-3 houdini-$version
 
 outdir=$REPO_PATH/houdini/stubs/
 
-export PYTHONPATH=$REPO_PATH/../mypy:$REPO_PATH/core/python:$REPO_PATH/.venv-py37-linux/lib/python3.7/site-packages:$REPO_PATH/houdini/bin/
+export PYTHONPATH=$REPO_PATH/core/python:$REPO_PATH/.venv-py37-linux/lib/python3.7/site-packages:$REPO_PATH/houdini/bin/
 export PATH=${REPO_PATH}/houdini/bin:${PATH}
 hython -c "import stubgen_houdini;stubgen_houdini.main(['-m', 'hou', '--parse-only', '--verbose', '-o=.out'])"
 

--- a/katana/stubgen_katana.sh
+++ b/katana/stubgen_katana.sh
@@ -11,13 +11,12 @@ fi
 export REPO_PATH=$(git rev-parse --show-toplevel)
 
 # Custom variables --
-MYPY_ROOT=$REPO_PATH/../mypy
 export KATANA_HOME=/luma/soft/applications/Foundry/Linux-x86_64/katana/Katana-$version
 export PATH=$KATANA_HOME:$PATH
 export foundry_LICENSE='4101@katanalicgui.luma.ninja:5053@katanarender.luma.ninja'
 # End custom variables --
 
-export PYTHONPATH=$REPO_PATH:$REPO_PATH/katana:$MYPY_ROOT:$PY_SITE_DIR
+export PYTHONPATH=$REPO_PATH:$REPO_PATH/katana:$PY_SITE_DIR
 
 sitedir=$KATANA_HOME/bin/python/
 outdir=${REPO_PATH}/katana/stubs

--- a/mari/stubgen_mari.sh
+++ b/mari/stubgen_mari.sh
@@ -18,6 +18,6 @@ REPO_PATH=$(git rev-parse --show-toplevel)
 
 outdir=$REPO_PATH/mari/stubs/
 
-export PYTHONPATH=$REPO_PATH:$REPO_PATH/mari:$REPO_PATH/../mypy/:$PY_SITE_DIR
+export PYTHONPATH=$REPO_PATH:$REPO_PATH/mari:$PY_SITE_DIR
 
 ${REPO_PATH}/mari/maripy -c "import stubgen_mari;stubgen_mari.main('$outdir')" || true

--- a/nuke/stubgen_nuke.sh
+++ b/nuke/stubgen_nuke.sh
@@ -10,7 +10,6 @@ outdir=$REPO_PATH/nuke/stubs/
 
 # using $NUKE_APP/python3 crashes in my latest tests
 # must import nuke to make nuke modules available, but this consumes sys.argv, so we have to get a bit hacky
-export PYTHONPATH=$REPO_PATH/../mypy
 
 $REPO_PATH/nuke/bin/nukepy -c "import _nuke;import sys;sys.argv=['foo', '-o=$outdir', '-m', '_nuke', '-p', 'nuke_internal', '-m', '_curveknob', '-m', '_nuke_color', '-m', '_curvelib', '-m', '_geo', '-m', '_localization', '-m', '_splinewarp']; import mypy.stubgen;mypy.stubgen.main()"
 

--- a/ocio/stubgen_ocio.sh
+++ b/ocio/stubgen_ocio.sh
@@ -5,10 +5,9 @@ REPO_PATH=$(git rev-parse --show-toplevel)
 outdir=$REPO_PATH/ocio/stubs/
 
 # Custom variables --
-MYPY_ROOT=$REPO_PATH/../mypy
 # End custom variables --
 
-export PYTHONPATH=$REPO_PATH:$REPO_PATH/ocio:$MYPY_ROOT:$PY_SITE_DIR
+export PYTHONPATH=$REPO_PATH:$REPO_PATH/ocio:$PY_SITE_DIR
 
 #python -m mypy.stubgen -m PyOpenColorIO -o $outdir
 python -m stubgen_ocio -m PyOpenColorIO -o $outdir

--- a/pyside/stubgen_pyside.sh
+++ b/pyside/stubgen_pyside.sh
@@ -3,7 +3,6 @@ set -e
 
 POINT_RELEASE=5
 
-#pip install -U git+https://github.com/chadrik/mypy@stubgenc-all-fixes#mypy
 # pip install -U -e ../mypy
 
 PY_SITE_DIR=$(python -c "import site,os;print(os.pathsep.join(site.getsitepackages()))")
@@ -11,10 +10,9 @@ REPO_PATH=$(git rev-parse --show-toplevel)
 outdir=$REPO_PATH/pyside/stubs/
 
 # Custom variables --
-MYPY_ROOT=$REPO_PATH/../mypy
 # End custom variables --
 
-export PYTHONPATH=$REPO_PATH:$REPO_PATH/pyside:$MYPY_ROOT:$PY_SITE_DIR
+export PYTHONPATH=$REPO_PATH:$REPO_PATH/pyside:$PY_SITE_DIR
 
 python -m stubgen_pyside -p shiboken2 -p PySide2 --include-private -o $outdir
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 docstring_parser
-mypy==1.4.0
+mypy==1.9.0

--- a/stubgenlib.py
+++ b/stubgenlib.py
@@ -68,7 +68,7 @@ def merge_signatures(
     if dest.is_special_method() and len(other.args) == len(dest.args):
         for arg, other_arg in zip(dest.args, other.args):
             if (arg.type is None or force) and other_arg.type is not None:
-                arg = ArgSig(arg.name, other_arg.type, arg.default)
+                arg = ArgSig(arg.name, other_arg.type, default=arg.default)
             args.append(arg)
     else:
         other_args = {arg.name: arg for arg in other.args}
@@ -76,7 +76,7 @@ def merge_signatures(
             if arg.name in other_args:
                 other_arg = other_args[arg.name]
                 if (arg.type is None or force) and other_arg.type is not None:
-                    arg = ArgSig(arg.name, other_arg.type, arg.default)
+                    arg = ArgSig(arg.name, other_arg.type, default=arg.default)
             args.append(arg)
 
     ret_type = dest.ret_type
@@ -133,7 +133,7 @@ class BaseSigFixer:
                         )
                     )
                     type_name = None
-            args.append(ArgSig(arg.name, type_name, arg.default))
+            args.append(ArgSig(arg.name, type_name, default=arg.default))
         if sig.ret_type:
             return_type = self.cleanup_type(sig.ret_type, ctx, is_result=True)
             if not self.is_valid(return_type):
@@ -166,7 +166,7 @@ class BaseSigFixer:
                 sig = self.cleanup_sig_types(sig, ctx)
                 if self.default_sig_handling == "ignore":
                     merged_sig = sig
-                elif default_sig.is_identity() or (
+                elif default_sig.is_catchall_signature() or (
                     default_sig.has_catchall_args()
                     and default_sig.ret_type == sig.ret_type
                 ):

--- a/usd/stubgen_usd.sh
+++ b/usd/stubgen_usd.sh
@@ -5,13 +5,12 @@ set -e
 REPO_PATH=$(git rev-parse --show-toplevel)
 
 # Custom variables --
-MYPY_ROOT=$REPO_PATH/../mypy
 export USD_BUILD_ROOT=~/dev/USD/.build-py-sigs
 export USD_SOURCE_ROOT=~/dev/USD_private_chadrik
 # End custom variables --
 
 export USD_XML_INDEX="${USD_BUILD_ROOT}/docs/doxy_xml/index.xml"
-export PYTHONPATH=$REPO_PATH:$REPO_PATH/usd:$MYPY_ROOT:$USD_BUILD_ROOT/lib/python:$USD_SOURCE_ROOT/docs/python
+export PYTHONPATH=$REPO_PATH:$REPO_PATH/usd:$USD_BUILD_ROOT/lib/python:$USD_SOURCE_ROOT/docs/python
 
 outdir=$REPO_PATH/usd/stubs
 


### PR DESCRIPTION
I noticed the changes from the forked version of mypy had been merged. I was able to build ocio docs with a newer version of mypy. Unfortunately, mypy dropped Python 3.7 support. So I updated the references in the README to use Python 3.9.

I didn't include newer ocio stubs in this commit. I also don't have access to the other packages to test or contribute those.