### PR TITLE
Fix QCoreApplication.instance requiring an argument

### DIFF
--- a/pyside/stubs/PySide2-stubs/QtCore.pyi
+++ b/pyside/stubs/PySide2-stubs/QtCore.pyi
@@ -5,6 +5,10 @@ import shiboken2
 import typing
 T = typing.TypeVar('T')
 import typing_extensions
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 QtCriticalMsg: QtMsgType
 QtDebugMsg: QtMsgType
@@ -2041,7 +2045,7 @@ class QCoreApplication(QObject):
     @staticmethod
     def installTranslator(messageFile: QTranslator) -> bool: ...
     @staticmethod
-    def instance(cls: typing.Type[T]) -> T: ...
+    def instance() -> Self: ...
     @staticmethod
     def isQuitLockEnabled() -> bool: ...
     @staticmethod


### PR DESCRIPTION
Fixes #17

I've tested this by running mypy against the following code:

```python
from PySide2 import QtCore, QtGui, QtWidgets

qcoreapp: QtCore.QCoreApplication = QtCore.QCoreApplication.instance()
qguiapp: QtGui.QGuiApplication = QtGui.QGuiApplication.instance()
qapp: QtWidgets.QApplication = QtWidgets.QApplication.instance()
```

mypy fails without this change, and passes with the change.