### PR TITLE
houdini: fix Node.inputs() and OpNodeTypeCategory.nodeType()

### DIFF
--- a/houdini/hou_cleanup_config.py
+++ b/houdini/hou_cleanup_config.py
@@ -477,6 +477,7 @@ MISSING_DEFINITIONS = {
     ],
     "OpNodeTypeCategory": [
         "def nodeTypes(self) -> dict[str, OpNodeType]",
+        "def nodeType(self, type_name: str) -> Optional[OpNodeType]",
     ],
     "Parm": [
         "def appendMultiParmInstancesFromData(self, data: Sequence[dict[str, Any]]) -> None",
@@ -1656,7 +1657,7 @@ EXPLICIT_DEFINITIONS = {
         "deleteItems": "(self, items: Iterable[NetworkMovableItem], disable_safety_checks: bool = False) -> None",
         "input": "(self, input_index: int) -> Self | None",
         "inputFollowingOutputs": "(self, input_index: int) -> Self | None",
-        "inputs": "(self) -> Tuple[Self, ...]",
+        "inputs": "(self) -> Tuple[Self | None, ...]",
         "layoutChildren": "(self, items: Sequence[NetworkMovableItem] = ..., horizontal_spacing: float = 1.0, vertical_spacing: float = 1.0) -> None",
         "outputs": "(self) -> Tuple[Self, ...]",
         "recursiveGlob": "(self, pattern: str, filter: EnumValue = nodeTypeFilter.NoFilter, include_subnets: bool = True) -> Tuple[Node, ...]",

--- a/houdini/pyproject.toml
+++ b/houdini/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "types-houdini"
-version = "21.0.512.0"
+version = "21.0.512.1"
 
 readme = "README.md"
 authors = [{name="Chad Dombrova"}, {name="Ben Andersen"}]

--- a/houdini/stubs/hou-stubs/__init__.pyi
+++ b/houdini/stubs/hou-stubs/__init__.pyi
@@ -10003,7 +10003,7 @@ class Node(NetworkMovableItem):
 
 
         """
-    def inputs(self) -> Tuple[Self,...]:
+    def inputs(self) -> Tuple[Self|None,...]:
         """
 
         inputs(self) -> tuple of hou.Node
@@ -16123,6 +16123,7 @@ class OpNodeTypeCategory(NodeTypeCategory):
 
     # Missing methods added by stubgen
     def nodeTypes(self) -> dict[str, OpNodeType]: ...  # type: ignore[override]
+    def nodeType(self, type_name: str) -> Optional[OpNodeType]: ...
 
 class ParmTemplate:
     '''

--- a/houdini/uv.lock
+++ b/houdini/uv.lock
@@ -41,7 +41,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mypy", specifier = ">=1.15.0,<1.17.0" },
+    { name = "mypy", specifier = ">=1.15.0,<1.20.0" },
     { name = "typeguard" },
 ]
 
@@ -62,7 +62,7 @@ wheels = [
 
 [[package]]
 name = "types-houdini"
-version = "21.0.512.0"
+version = "21.0.512.1"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
Closes https://github.com/LumaPictures/cg-stubs/issues/11 and fixes an issue we have with `OpNodeTypeCategory.nodeType()` returning `NodeType` instead of `OpNodeType()`