### PR TITLE
Generating substance_painter stubs

### DIFF
--- a/substance_painter/gen/_connection.py
+++ b/substance_painter/gen/_connection.py
@@ -1,0 +1,63 @@
+import http.client
+import json
+import base64
+
+
+
+class PainterError(Exception):
+    def __init__(self, message):
+        super(PainterError, self).__init__(message)
+
+
+class ExecuteScriptError(PainterError):
+    def __init__(self, data):
+        super(PainterError, self).__init__('An error occurred when executing script: {0}'.format(data))
+
+
+class RemotePainter() :
+    def __init__(self, port=60041, host='localhost'):
+        self._host = host
+        self._port = port
+
+        # Json server connection
+        self._PAINTER_ROUTE = '/run.json'
+        self._HEADERS = {
+            'Content-type': 'application/json',
+            'Accept': 'application/json'
+        }
+
+    # Execute a HTTP POST request to the Substance Painter server and send/receive JSON data
+    def _jsonPostRequest( self, route, body, type ) :
+        connection = http.client.HTTPConnection(self._host, self._port, timeout=3600)
+        connection.request('POST', route, body, self._HEADERS)
+        response = connection.getresponse()
+
+        data = response.read()
+        connection.close()
+
+        if type == "js" :
+            data = json.loads( data.decode('utf-8') or "" ).strip()
+
+        j_data = json.loads(data)
+        if j_data and isinstance(j_data, dict) and 'error' in j_data:
+            raise ExecuteScriptError(j_data['error']["description"])
+
+        return data
+
+    def checkConnection(self):
+        connection = http.client.HTTPConnection(self._host, self._port)
+        connection.connect()
+
+    # Execute a command
+    def execScript( self, script, type ) :
+        Command = base64.b64encode( script.encode('utf-8') )
+
+        if type == "js" :
+            Command = '{{"js":"{0}"}}'.format( Command.decode('utf-8') )
+        else :
+            Command = '{{"python":"{0}"}}'.format( Command.decode('utf-8') )
+
+        Command = Command.encode( "utf-8" )
+
+        return self._jsonPostRequest( self._PAINTER_ROUTE, Command, type )
+

--- a/substance_painter/gen/generate_stubs.py
+++ b/substance_painter/gen/generate_stubs.py
@@ -1,0 +1,22 @@
+import textwrap
+from pathlib import Path
+import sys
+
+if not Path(__file__).parent.parent.as_posix() in sys.path:
+    sys.path.append(Path(__file__).parent.parent.as_posix())
+
+from gen import _connection
+
+def generate_stubs(out_dir, site_packages):
+    data = f"""
+    print("DEBUG   | Adding {site_packages} to sys.path")
+    print("DEBUG   | Output to {out_dir}/stubs/")
+    import sys; sys.path.append("{site_packages}")
+    import stubgenlib.moduleinspect; stubgenlib.moduleinspect.patch()
+    import mypy.stubgen; mypy.stubgen.main(['-p', '_substance_painter', '-o', '{out_dir}/stubs/'])
+    """
+    _connection.RemotePainter().execScript(textwrap.dedent(data), "python")
+
+
+this = Path(__file__).absolute().parent.parent
+generate_stubs(this.as_posix(), (this / ".venv" / "Lib" / "site-packages").as_posix())

--- a/substance_painter/gen/patch_stubs.py
+++ b/substance_painter/gen/patch_stubs.py
@@ -1,0 +1,72 @@
+
+import pathlib
+import re
+
+outdir = pathlib.Path(__file__).parent.parent / "stubs" / "substance_painter-stubs"
+
+# Fix event.pyi: replace _Number with Union[int, float]
+event_pyi = outdir / "event.pyi"
+text = event_pyi.read_text()
+text = re.sub(r"\b_Number\b", "Union[int, float]", text)
+text = text.replace("from _typeshed import Incomplete", "from typing import Union")
+text = text.replace("DISPATCHER: Incomplete", "DISPATCHER: Dispatcher")
+event_pyi.write_text(text)
+
+# For each .pyi file, replace CamelCase: Incomplete with an import from _substance_painter
+print("Patching Incomplete Class reference")
+for file in sorted(outdir.glob("*.pyi")):
+    name = file.stem
+    print(f"  {file} ({name})")
+    text = file.read_text()
+    text = re.sub(
+        r"\b([A-Z]+[a-z][a-zA-Z0-9_]+): Incomplete",
+        rf"from _substance_painter.{name} import \1 as \1",
+        text,
+    )
+    file.write_text(text)
+
+
+# Add missing import
+print("Patching missing types import")
+for path in [outdir / "layerstack.pyi", outdir / "project.pyi"]:
+    with open(path, "r") as f:
+        data = f.read()
+
+    if "import types" not in data:
+        data = "import types\n" + data
+
+        with open(path, "w") as f:
+            f.write(data)
+
+
+# In each stub file replace floatN and intN.
+print("Patching floatN and intN")
+for file in sorted(outdir.parent.glob("**/*.pyi")):
+    name = file.stem
+    print(f"  {file} ({name})")
+    text = file.read_text()
+    text = re.sub(
+        r"(float|int)\d+",
+        rf"\1",
+        text,
+    )
+    file.write_text(text)
+
+
+# Path accept None as Default
+# print("None as Default")
+# for file in sorted(outdir.parent.glob("**/*.pyi")):
+#     name = file.stem
+#     print(f"  {file} ({name})")
+#     text = file.read_text()
+#     text = re.sub(
+#         r": str = None",
+#         rf": str",
+#         text,
+#     )
+#     text = re.sub(
+#         r": list[str] = None",
+#         rf": list[str]",
+#         text,
+#     )
+#     file.write_text(text)

--- a/substance_painter/gen/update_version.py
+++ b/substance_painter/gen/update_version.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+import re
+import sys
+import datetime
+
+
+if not Path(__file__).parent.parent.as_posix() in sys.path:
+    sys.path.append(Path(__file__).parent.parent.as_posix())
+
+from gen import _connection
+
+_connection.RemotePainter().execScript("import substance_painter", "python")
+version = _connection.RemotePainter().execScript("substance_painter.application.version()", "python")
+
+# Include year?
+# currentDateTime = datetime.datetime.now()
+# date = currentDateTime.date()
+# year = date.strftime("%Y")
+
+if version:
+    version = version.decode('''utf-8''').strip().strip('"')
+    with open(Path(__file__).parent.parent / "pyproject.toml", "r") as f:
+        text = f.read()
+    with open(Path(__file__).parent.parent / "pyproject.toml", "w") as f:
+        text = re.sub(
+            r'version = "(.*)"',
+            #rf'version = "{year}.{version}"',
+            rf'version = "{version}"',
+            text,
+        )
+        f.write(text)
+else:
+    print("Could not find any version")

--- a/substance_painter/justfile
+++ b/substance_painter/justfile
@@ -1,0 +1,31 @@
+set shell := ["sh", "-c"]
+set windows-shell := ["powershell.exe", "-NoLogo", "-Command"]
+
+PAINTER_DIRECTORY := "C:/Program Files/Adobe/Adobe Substance 3D Painter"
+PAINTER_EXE := "Adobe Substance 3D Painter.exe"
+PYTHON_MODULE := "resources/python/modules/substance_painter"
+
+init:
+  uv sync --group dev
+
+source:
+  .venv/Scripts/activate.bat
+
+painter:
+  "{{PAINTER_DIRECTORY}}\{{PAINTER_EXE}}" --enable-remote-scripting
+
+generate: source
+  if (Test-Path stubs) {Remove-Item stubs -Recurse}
+  mkdir stubs
+  python gen/generate_stubs.py
+  stubgen --o stubs "{{PAINTER_DIRECTORY}}/{{PYTHON_MODULE}}"
+  mv stubs/substance_painter stubs/substance_painter-stubs
+  mv stubs/_substance_painter stubs/_substance_painter-stubs
+  python gen/patch_stubs.py
+
+bump-version: source
+  python gen/update_version.py
+
+build: bump-version
+  uv build
+  git restore pyproject.toml


### PR DESCRIPTION
The substance_painter stubs generation was a bit too manual and hard to follow so I quickly threw together a proof of concept of how to generate without so much manual work.

I am not 100% sure how this repository work, and wont have time to look into it in the near future. So if this approach interests you please adopt it for the repository.

## Building stubs.
**Requirements**

* [uv](https://docs.astral.sh/uv/)
* [just](https://github.com/casey/just)

**Building**

Building consists of these steps.

> [!Note]
>
> You might have to update the paths in the `justfile`

* Prepare
  * `just init`
* Launch Painter
  * `just painter`
  * Wait for painter to be launched and ready.
* Generate Stubs
  * `just generate`
* Bump version
  * `just bump-version`
 