### PR TITLE
Substance painter/docs

### DIFF
--- a/substance_painter/README.md
+++ b/substance_painter/README.md
@@ -19,7 +19,7 @@ plus a version suffix for the revision of the stubs.
 
 The `_substance_painter` modules are accessible within Substance Painter. You'll need to run stubgen from inside the console. Mypy by default launches a subprocess when doing stubgen, which isn't what we want. So we patch that behavior with `common\src\stubgenlib\moduleinspect.py`. For that to work, you'll need to ensure that your Mypy install is pure-python.
 
-```
+```sh
 # Ensure our mypy is the same version as substance, so we'll be able to import it.
 cd cg-stubs/substance_painter && uv sync --python 3.11
 # launch painter in the root directory
@@ -28,10 +28,10 @@ painter
 
 Within painter:
 
-```
+```py
 import sys; sys.path.append("substance_painter/.venv/Lib/site-packages")
 import stubgenlib.moduleinspect; stubgenlib.moduleinspect.patch()
-import mypy.stubgen; mypy.stubgen.main(['-p', '_substance_painter', '-o', 'substance_painter/stubs'])
+import mypy.stubgen; mypy.stubgen.main(['-p', '_substance_painter', '-o', 'substance_painter/stubs', '--include-docstrings'])
 ```
 
 * `sys.path.insert(0, ".venv/Lib/site-packages")` to put our mypy install on path.
@@ -41,8 +41,9 @@ import mypy.stubgen; mypy.stubgen.main(['-p', '_substance_painter', '-o', 'subst
 ### Extract stubs from the Substance Painter folder
 
 In the root of the repository, run:
-```
-uv run --directory substance_painter stubgen --no-import $SUBSTANCE_PAINTER_ROOT/resources/python/modules/substance_painter/ --search-path ./stubs -o ./stubs
+
+```sh
+uv run --directory substance_painter stubgen --no-import "$SUBSTANCE_PAINTER_ROOT/resources/python/modules/substance_painter/" --include-docstrings --search-path ./stubs -o ./stubs
 ```
 
 * set `$SUBSTANCE_PAINTER_ROOT` to the substance painter install directory.
@@ -51,7 +52,7 @@ uv run --directory substance_painter stubgen --no-import $SUBSTANCE_PAINTER_ROOT
 
 ### Run nox target
 
-```
+```sh
 nox -s 'generate(substance_painter)'
 ```
 

--- a/substance_painter/stubs/substance_painter-stubs/_executor.pyi
+++ b/substance_painter/stubs/substance_painter-stubs/_executor.pyi
@@ -2,7 +2,13 @@ from . import event as event
 from _typeshed import Incomplete
 
 class ProjectExecutor:
+    """
+    Execute code at specific project dependant times.
+    """
     def __init__(self, dispatcher) -> None: ...
-    def execute_when_not_busy(self, callback) -> None: ...
+    def execute_when_not_busy(self, callback) -> None:
+        """
+        Execute code when the application is not in a busy state.
+        """
 
 PROJECT_EXECUTOR: Incomplete

--- a/substance_painter/stubs/substance_painter-stubs/_utility.pyi
+++ b/substance_painter/stubs/substance_painter-stubs/_utility.pyi
@@ -1,17 +1,60 @@
-def is_mock(obj): ...
-def expose_private_obj(obj, module_name, fields=None, class_name=None): ...
-def type_mismatch_error_message(argument_name: str, expected_argument_type) -> str: ...
-def flatten_attributes(src, dst, overrides=None) -> None: ...
-def unflatten_attributes(src, dst, overrides=None) -> None: ...
-def is_power_of_two(val: int) -> bool: ...
-def restrict_float_range(name: str, lower_bound: float, upper_bound: float): ...
-def restrict_float_lower_bound(name: str, lower_bound: float): ...
-def restrict_color(name: str): ...
-def restrict_resolution(name: str, lower_bound: int, upper_bound: int): ...
-def restrict_positive_rect(name: str): ...
+def is_mock(obj):
+    """Returns ``True`` if 'obj' is a mock, ``False`` otherwise.
+
+    Just check if the unittest.moc.Mock.side_effect method exists.
+    WARNING: don't try to use 'isinstance' because mock object
+    appears as mocked object.
+    """
+def expose_private_obj(obj, module_name, fields=None, class_name=None):
+    """This method allows for proper documentation generation when exposing
+    an object form the private API through the public API. The corresponding
+    object needs to be documented from python or sphinx files (doc strings
+    from the private API wont be imported during documentation generation, but
+    they will still be available at runtime to be used with the `help`
+    builtin function).
+
+    Returns 'obj' if not a mock object. Otherwise, inject a class with the same
+    class name in the module 'module_name'. Optionally a list of 'fields' can
+    be supplied if necessary for documention generation.
+    """
+def type_mismatch_error_message(argument_name: str, expected_argument_type) -> str:
+    """Returns a formatted error message for TypeError exceptions.
+    """
+def flatten_attributes(src, dst, overrides=None) -> None:
+    """Flatten all attributes from src hierarchy in dst."""
+def unflatten_attributes(src, dst, overrides=None) -> None:
+    """Load all attributes from src flat object into dst hierarchy."""
+def is_power_of_two(val: int) -> bool:
+    """Returns true if val is a power of 2, false otherwise"""
+def restrict_float_range(name: str, lower_bound: float, upper_bound: float):
+    """__set_attr__ decorator to enforce a lower and upper bound on a float value."""
+def restrict_float_lower_bound(name: str, lower_bound: float):
+    """__set_attr__ decorator to enforce a lower bound on a float value."""
+def restrict_color(name: str):
+    """
+    __set_attr__ decorator to make sure the modified value is a list of 3 values always
+    between 0 and 1.
+    """
+def restrict_resolution(name: str, lower_bound: int, upper_bound: int):
+    """
+    __set_attr__ decorator to make sure the resolution is always a power
+    of 2 value and in range [lower_bound, upper_bound].
+    """
+def restrict_positive_rect(name: str):
+    """__set_attr__ decorator to make sure the rect is positive."""
 
 class ReadOnlyUid:
+    """Class with a read-only uid"""
     def __init__(self, uid) -> None: ...
     def __setattr__(self, name, value) -> None: ...
     def __eq__(self, other): ...
-    def uid(self) -> int: ...
+    def uid(self) -> int:
+        """
+        Get the object internal uid.
+
+        Returns:
+            int: The internal identifier of the object as an integer.
+        """
+
+def make_callable(value):
+    """Make value callable, usefull when migrating from getter to property."""

--- a/substance_painter/stubs/substance_painter-stubs/application.pyi
+++ b/substance_painter/stubs/substance_painter-stubs/application.pyi
@@ -1,10 +1,54 @@
 import contextlib
 from collections.abc import Generator
 
-def version_info() -> tuple[int, int, int]: ...
-def version() -> str: ...
-def engine_computations_status() -> bool: ...
-def enable_engine_computations(enable: bool): ...
+def version_info() -> tuple[int, int, int]:
+    """
+    Get the version_info of Substance 3D Painter. Ie a tuple containing major, minor, patch.
+
+    Returns:
+        Tuple[int, int, int]: The major, minor and patch version of Substance 3D Painter.
+    """
+def version() -> str:
+    """
+    Get the version of Substance 3D Painter. Do not extract version information out of it,
+    rather use :func:`version_info`.
+
+    Returns:
+        str: Version of Substance 3D Painter.
+    """
+def engine_computations_status() -> bool:
+    """
+    Check whether engine computations are enabled.
+
+    Returns:
+        bool: Whether engine computations are enabled.
+    """
+def enable_engine_computations(enable: bool):
+    """
+    Enable or disable engine computations.
+    """
 @contextlib.contextmanager
-def disable_engine_computations() -> Generator[None]: ...
-def close() -> None: ...
+def disable_engine_computations() -> Generator[None]:
+    """
+    Context manager to disable engine computations.
+    Allows to regroup computation intensive tasks without triggerring the engine so that textures
+    are not computed or updated in the layer stack or the viewport.
+    This is equivalent to disabling and then reenabling the engine by calling
+    :func:`enable_engine_computations`.
+
+    Example:
+    ::
+
+        import substance_painter.application as mapplication
+
+        with mapplication.disable_engine_computations():
+            # Do some computation intensive tasks
+            pass
+    """
+def close() -> None:
+    """
+    Close Susbtance 3D Painter.
+
+    Warning:
+        Any unsaved data will be lost.
+    """

--- a/substance_painter/stubs/substance_painter-stubs/async_utils.pyi
+++ b/substance_painter/stubs/substance_painter-stubs/async_utils.pyi
@@ -3,7 +3,22 @@ import dataclasses
 
 @dataclasses.dataclass(frozen=True)
 class StopSource:
+    """
+    An object that can be used to cancel an asynchronous computation.
+    """
     stop_source: _substance_painter.async_utils.StopSource
     def __bool__(self) -> bool: ...
-    def request_stop(self) -> bool: ...
-    def stop_requested(self) -> bool: ...
+    def request_stop(self) -> bool:
+        """
+        Makes a top request.
+
+        Returns:
+            bool: True if the stop request was possible.
+        """
+    def stop_requested(self) -> bool:
+        """
+        Check if a stop request as been made.
+
+        Returns:
+            bool: True if a stop request has been made.
+        """

--- a/substance_painter/stubs/substance_painter-stubs/baking.pyi
+++ b/substance_painter/stubs/substance_painter-stubs/baking.pyi
@@ -9,36 +9,331 @@ from _substance_painter.baking import CurvatureMethod as CurvatureMethod
 
 @dataclasses.dataclass(frozen=True)
 class BakingParameters:
+    """
+    Baking parameters for a given texture set.
+
+    Example:
+        ::
+
+            # This example shows how to discover the names of the baking parameters
+            import substance_painter as sp
+
+            # Get the first texture set of the current project
+            textureset = sp.textureset.all_texture_sets()[0]
+            # Retrieve baking parameters
+            baking_params = sp.baking.BakingParameters.from_texture_set(textureset)
+
+            # Print the keys of the common baking parameters
+            print(f'Common: {baking_params.common().keys()}')
+            # Print the keys of the baking parameters of the AO mesh map
+            print(f'AO: {baking_params.baker(sp.baking.MeshMapUsage.AO).keys()}')
+
+    See also:
+        :class:`substance_painter.textureset.TextureSet`,
+        :class:`substance_painter.textureset.MeshMapUsage`
+    """
     material_id: int
     @staticmethod
-    def from_texture_set(texture_set: TextureSet) -> BakingParameters: ...
-    @staticmethod
-    def from_texture_set_name(texture_set_name: str) -> BakingParameters: ...
-    def texture_set(self) -> TextureSet: ...
-    def common(self) -> dict[str, Property]: ...
-    def baker(self, baked_map: MeshMapUsage) -> dict[str, Property]: ...
-    @staticmethod
-    def set(property_values: dict[Property, PropertyValue]) -> None: ...
-    def get_curvature_method(self) -> CurvatureMethod: ...
-    def set_curvature_method(self, method: CurvatureMethod): ...
-    def is_baker_enabled(self, usage: MeshMapUsage) -> bool: ...
-    def set_baker_enabled(self, usage: MeshMapUsage, enable: bool) -> None: ...
-    def get_enabled_bakers(self) -> list[MeshMapUsage]: ...
-    def set_enabled_bakers(self, enabled_usages: list[MeshMapUsage]) -> None: ...
-    def is_textureset_enabled(self) -> bool: ...
-    def set_textureset_enabled(self, enable: bool) -> None: ...
-    def is_uv_tile_enabled(self, uv_tile: UVTile) -> bool: ...
-    def set_uv_tile_enabled(self, uv_tile: UVTile, enable: bool) -> None: ...
-    def get_enabled_uv_tiles(self) -> list[UVTile]: ...
-    def set_enabled_uv_tiles(self, enabled_uv_tiles: list[UVTile]) -> None: ...
+    def from_texture_set(texture_set: TextureSet) -> BakingParameters:
+        """
+        Get the baking parameters for the given texture set object.
 
-def set_linked_group(group: list[TextureSet], reference: TextureSet, usage: MeshMapUsage) -> None: ...
-def set_linked_group_common_parameters(group: list[TextureSet], reference: TextureSet) -> None: ...
-def unlink_all(usage: MeshMapUsage) -> None: ...
-def unlink_all_common_parameters() -> None: ...
-def get_link_group(usage: MeshMapUsage) -> list[TextureSet]: ...
-def get_link_group_common_parameters() -> list[TextureSet]: ...
-def get_linked_texture_sets(texture_set: TextureSet, usage: MeshMapUsage) -> list[TextureSet]: ...
-def get_linked_texture_sets_common_parameters(texture_set: TextureSet) -> list[TextureSet]: ...
-def bake_async(texture_set: TextureSet) -> StopSource: ...
-def bake_selected_textures_async() -> StopSource: ...
+        Args:
+            texture_set (TextureSet): The texture set.
+
+        Returns:
+            BakingParameters: The baking parameters for the given texure set.
+
+        See also:
+            :class:`substance_painter.textureset.TextureSet`
+        """
+    @staticmethod
+    def from_texture_set_name(texture_set_name: str) -> BakingParameters:
+        """
+        Get the baking parameters for the given texture set name.
+
+        Args:
+            texture_set_name (str): The texture set name.
+
+        Returns:
+            BakingParameters: The baking parameters for the given texure set.
+
+        See also:
+            :class:`substance_painter.properties.Property`
+        """
+    def texture_set(self) -> TextureSet:
+        """
+        Get the associated texture set.
+
+        Returns:
+            TextureSet: The texture set associated with this BakingParameters instance.
+
+        See also:
+            :class:`substance_painter.textureset.TextureSet`
+        """
+    def common(self) -> dict[str, Property]:
+        """
+        Get the parameters common to all bakers, like baking resolution.
+
+        Returns:
+            Dict[str, Property]: The common parameters.
+
+        See also:
+            :class:`substance_painter.properties.Property`
+        """
+    def baker(self, baked_map: MeshMapUsage) -> dict[str, Property]:
+        """
+        Get the parameters specific to a given baked map.
+
+        Args:
+            baked_map (MeshMapUsage): The baked map usage.
+
+        Returns:
+            Dict[str, Property]: The corresponding baked map parameters.
+
+        See also:
+            :class:`substance_painter.textureset.MeshMapUsage`,
+            :class:`substance_painter.properties.Property`
+        """
+    @staticmethod
+    def set(property_values: dict[Property, PropertyValue]) -> None:
+        """
+        Set property values in batch.
+
+        Args:
+            property_values (Dict[Property, PropertyValue]): A dict of properties
+                to be set with their corresponding new values.
+
+        See also:
+            :class:`substance_painter.properties.Property`
+        """
+    def get_curvature_method(self) -> CurvatureMethod:
+        """
+        Get the curvature method used for baking
+
+        Returns:
+            CurvatureMethod: The curvature method used for baking
+
+        See Also:
+            `set_curvature_method`
+        """
+    def set_curvature_method(self, method: CurvatureMethod):
+        """
+        Set the curvature method to use for baking
+
+        Args:
+            method (CurvatureMethod): The new method to use for baking
+
+        See Also:
+            `get_curvature_method`
+        """
+    def is_baker_enabled(self, usage: MeshMapUsage) -> bool:
+        """
+        Whether some usage is enabled for baking.
+
+        Args:
+            usage (MeshMapUsage): The baked map usage.
+
+        Returns:
+            bool: True if the corresponding usage is enabled for baking.
+        """
+    def set_baker_enabled(self, usage: MeshMapUsage, enable: bool) -> None:
+        """
+        Enable or disable a usage for baking.
+
+        Args:
+            usage (MeshMapUsage): The baked map usage.
+            enable (bool): Enable or disable.
+        """
+    def get_enabled_bakers(self) -> list[MeshMapUsage]:
+        """
+        Get all usages enabled for baking.
+
+        Returns:
+            List[MeshMapUsage]: Enabled usages.
+        """
+    def set_enabled_bakers(self, enabled_usages: list[MeshMapUsage]) -> None:
+        """
+        Set usages enabled for baking. Usages not in this list will be disabled.
+
+        Args:
+            enabled_usages (List[MeshMapUsage]): Enabled usages.
+        """
+    def is_textureset_enabled(self) -> bool:
+        """
+        Whether this Texture Set is enabled for baking.
+
+        Returns:
+            bool: True if this Texture Set is enabled for baking.
+        """
+    def set_textureset_enabled(self, enable: bool) -> None:
+        """
+        Enable or disable this Texture Set for baking.
+
+        Args:
+            enable (bool): Enable or disable.
+        """
+    def is_uv_tile_enabled(self, uv_tile: UVTile) -> bool:
+        """
+        Whether a UV Tile is enabled for baking.
+
+        Args:
+            tile (UVTile): The UV Tile.
+
+        Returns:
+            bool: True if the UV Tile is enabled for baking.
+
+        See also:
+            :class:`substance_painter.textureset.TextureSet`,
+            :class:`substance_painter.textureset.UVTile`
+        """
+    def set_uv_tile_enabled(self, uv_tile: UVTile, enable: bool) -> None:
+        """
+        Enable or disable an UV Tile for baking.
+
+        Args:
+            uv_tile (UVTile): The UV Tile.
+            enable (bool): Enable or disable.
+
+        See also:
+            :class:`substance_painter.textureset.TextureSet`,
+            :class:`substance_painter.textureset.UVTile`
+        """
+    def get_enabled_uv_tiles(self) -> list[UVTile]:
+        """
+        Get all UV Tiles enabled for baking.
+
+        Returns:
+            List[UVTile]: Enabled UV Tiles.
+
+        See also:
+            :class:`substance_painter.textureset.TextureSet`,
+            :class:`substance_painter.textureset.UVTile`
+        """
+    def set_enabled_uv_tiles(self, enabled_uv_tiles: list[UVTile]) -> None:
+        """
+        Set UV Tiles enabled for baking. All other tiles will be disabled.
+
+        Args:
+            enabled_uv_tiles (List[UVTile]): Enabled UV Tiles.
+
+        See also:
+            :class:`substance_painter.textureset.TextureSet`,
+            :class:`substance_painter.textureset.UVTile`
+        """
+
+def set_linked_group(group: list[TextureSet], reference: TextureSet, usage: MeshMapUsage) -> None:
+    """
+    Make a group of Texture Sets share the same baking parameters for the given 'usage'. After that,
+    editing the 'usage' parameters of one of the group's Texture Set will impact the whole group.
+
+    Args:
+        group (List[TextureSet]): Texture Sets to be included in the new group.
+        reference (TextureSet): Texture Set which parameters are applied to the whole group.
+        usage (MeshMapUsage): Usage of the group.
+    """
+def set_linked_group_common_parameters(group: list[TextureSet], reference: TextureSet) -> None:
+    """
+    Make a group of Texture Sets share the same baking common parameters. After that, editing a
+    common parameter of one of the group's Texture Set will impact the whole group.
+
+    Args:
+        group (List[TextureSet]): Texture Sets to be included in the new group.
+        reference (TextureSet): Texture Set which parameters are applied to the whole group.
+    """
+def unlink_all(usage: MeshMapUsage) -> None:
+    """
+    Unlink all Texture Sets for a given usage. That is, remove the group if it exists, so that all
+    Texture Sets have their own copy of the parameters.
+
+    Args:
+        usage (MeshMapUsage): Usage to unlink.
+    """
+def unlink_all_common_parameters() -> None:
+    """
+    Unlink all Texture Sets for common parameters. That is, remove the group if exists, so that all
+    Texture Sets have their own copy of the parameters.
+    """
+def get_link_group(usage: MeshMapUsage) -> list[TextureSet]:
+    """
+    Get the list of Texture Sets that share baking parameters for a given usage.
+
+    Args:
+        usage (MeshMapUsage): Usage to query.
+
+    Returns:
+        List[TextureSet]: All linked Texture Sets for the usage. Empty list if no Texture Set are
+        linked.
+    """
+def get_link_group_common_parameters() -> list[TextureSet]:
+    """
+    Get the list of Texture Sets that share common baking parameters.
+
+    Returns:
+        List[TextureSet]: All linked Texture Sets for common parameters. Empty list if no Texture
+        Set are linked.
+    """
+def get_linked_texture_sets(texture_set: TextureSet, usage: MeshMapUsage) -> list[TextureSet]:
+    """
+    Get the list of Texture Sets that share the same parameters as some Texture Set, for a given
+    usage.
+
+    Args:
+        texture_set (TextureSet): The Texture Set to query
+        usage (MeshMapUsage): The usage to query
+
+    Returns:
+        List[TextureSet]: The list of Texture Sets sharing parameters with the input Texture Set.
+        Contains at least the input Texture Set if no group exists for the usage.
+    """
+def get_linked_texture_sets_common_parameters(texture_set: TextureSet) -> list[TextureSet]:
+    """
+    Get the list of Texture Sets that share the same parameters as some Texture Set, for common
+    parameters.
+
+    Args:
+        texture_set (TextureSet): The Texture Set to query
+
+    Returns:
+        List[TextureSet]: The list of Texture Sets sharing common parameters with the input Texture
+        Set. Contains at least the input Texture Set if no group exists for common parameters.
+    """
+def bake_async(texture_set: TextureSet) -> StopSource:
+    """
+    Launch the baking process for a Texture Set, using the current baking configuration.
+    The configuration is set by setting baking parameters, enabling Texture Set, selecting UV Tiles
+    for baking, setting curvature method etc.
+    This function is asynchronous. When the baking process is finished, the
+    :class:`substance_painter.event.BakingProcessEnded` event is sent.
+
+    Args:
+        texture_set (TextureSet): The Texture Set to bake.
+
+    Returns:
+        StopSource: Can be used to cancel the asynchronous computation.
+
+    See Also:
+        :class:`BakingParameters`
+        :class:`substance_painter.event.BakingProcessAboutToStart`
+        :class:`substance_painter.event.BakingProcessProgress`
+        :class:`substance_painter.event.BakingProcessEnded`
+        :class:`substance_painter.async_utils.StopSource`
+    """
+def bake_selected_textures_async() -> StopSource:
+    """
+    Launch the baking process, using the current baking configuration.
+    The configuration is set by setting baking parameters, enabling Texture Set, selecting UV Tiles
+    for baking, setting curvature method etc.
+    This function is asynchronous. When the baking process is finished, the
+    :class:`substance_painter.event.BakingProcessEnded` event is sent.
+
+    Returns:
+        StopSource: Can be used to cancel the asynchronous computation.
+
+    See Also:
+        :class:`BakingParameters`
+        :class:`substance_painter.event.BakingProcessAboutToStart`
+        :class:`substance_painter.event.BakingProcessProgress`
+        :class:`substance_painter.event.BakingProcessEnded`
+        :class:`substance_painter.async_utils.StopSource`
+    """

--- a/substance_painter/stubs/substance_painter-stubs/colormanagement.pyi
+++ b/substance_painter/stubs/substance_painter-stubs/colormanagement.pyi
@@ -1,36 +1,174 @@
 from enum import Enum
 
 class GenericColorSpace(Enum):
+    """
+    Generic color spaces valid with any color space engine used.
+
+    Can be used for :class:`Color.color_space <Color>` or resources.
+
+    Members:
+
+    ================= ===========================
+    Name              Description
+    ================= ===========================
+    ``sRGB``          sRGB color space (IEC 61966-2-1:1999 in legacy mode)
+    ``Working``       working space used in the current project (Linear sRGB in legacy mode).
+    ``Raw``           Raw (no color space conversion).
+    ================= ===========================
+    """
     sRGB = ...
     Working = ...
     Raw = ...
 
 class LegacyColorSpace(Enum):
+    """
+    Legacy color spaces.
+
+    Don't use them to override your resource's color spaces, use
+    :class:`GenericColorSpace.Working <GenericColorSpace>` or
+    :class:`GenericColorSpace.sRGB <GenericColorSpace>` instead.
+
+    Can be used for resources only. Can't be used for :class:`Color.color_space <Color>`.
+
+    Members:
+
+    ================= ===========================
+    Name              Description
+    ================= ===========================
+    ``Linear``        Linear sRGB color space.
+    ``sRGB``          sRGB color space (IEC 61966-2-1:1999).
+    ================= ===========================
+    """
     Linear = ...
     sRGB = ...
 
 class DataColorSpace(Enum):
+    """
+    Data color spaces.
+
+    Color spaces used for not color managed channels such as metallic or height.
+
+    Can be used for resources only. Can't be used for :class:`Color.color_space <Color>`.
+
+    Members:
+
+    ================= ===========================
+    Name              Description
+    ================= ===========================
+    ``Data``          Data values, unsigned normalized or float.
+    ``DataSigned``    Signed -1..1 data values stored as 0..1 normalized values.
+    ================= ===========================
+    """
     Data = ...
     DataSigned = ...
 
 class NormalColorSpace(Enum):
+    """
+    Normal color spaces.
+
+    Color spaces used for normal channels to specify how to interpret normal data.
+
+    Can be used for resources only. Can't be used for :class:`Color.color_space <Color>`.
+
+    Members:
+
+    ================== ===========================
+    Name               Description
+    ================== ===========================
+    ``NormalXYZRight`` Normal map in OpenGL format.
+    ``NormalXYZLeft``  Normal map in Direct3D format.
+    ================== ===========================
+    """
     NormalXYZRight = ...
     NormalXYZLeft = ...
 ColorColorSpace = GenericColorSpace | str
 ResourceColorSpace = GenericColorSpace | LegacyColorSpace | DataColorSpace | NormalColorSpace | str
 
 class Color:
+    """
+    Describe a color (with a color space).
+
+    If you are not confortable with color spaces, you can create a color without
+    specifying the colorspace of the data. In this case the color space will be
+    deduced depending on the context where this color is used
+    (:class:`GenericColorSpace.sRGB <GenericColorSpace>` when used on a color managed
+    channel, :class:`GenericColorSpace.Raw <GenericColorSpace>` otherwise).
+
+    On color managed channel, we assume sRGB because it is the most common
+    color space used for computer screens, this is why many color pickers will give you
+    sRGB data. sRGB is also the standard color space for the web, so a lot of color
+    data you can get from the web will be sRGB encoded.
+
+    *A color object returned by the different accessor of our API will always have a
+    defined colorspace.*
+
+    :ivar value_raw: raw r,g,b data encoded in `color_space`.
+    :vartype value_raw: Tuple[float, float, float]
+    :ivar color_space: Color space in which `value_raw`
+        is encoded. If None, will be deduced depending on the context where this color
+        is used (:class:`GenericColorSpace.sRGB <GenericColorSpace>` when used on
+        a color managed channel, :class:`GenericColorSpace.Raw <GenericColorSpace>`
+        otherwise).
+    :vartype color_space: GenericColorSpace | str
+    :param r: Red component
+    :param g: Green component
+    :param b: Blue component
+    :param color_space: Color space in which the data are encoded.
+        If not specified, it will be deduced depending on the context where the color
+        is used (:class:`GenericColorSpace.sRGB <GenericColorSpace>` when used on
+        a color managed channel, :class:`GenericColorSpace.Raw <GenericColorSpace>`
+        otherwise) (default: None).
+    """
     value_raw: tuple[float, float, float]
     color_space: ColorColorSpace
-    def __init__(self, r: float, g: float, b: float, color_space: ColorColorSpace = None) -> None: ...  # type: ignore[assignment]
-    def convert(self, color_space: ColorColorSpace) -> tuple[float, float, float]: ...
+    def __init__(self, r: float, g: float, b: float, color_space: ColorColorSpace = None) -> None:  # type: ignore[assignment]
+        """
+        Color constructor
+        """
+    def convert(self, color_space: ColorColorSpace) -> tuple[float, float, float]:
+        """
+        Get r,g,b values encoded in the given color space
+
+        Args:
+            color_space: Color space in which you want the data encoded to.
+
+        Returns:
+            Tuple[float, float, float]: r,g,b data encoded in the given color space
+
+        Raises:
+            RuntimeError: if :class:`Color.color_space <Color>` is None
+        """
     @property
-    def value(self) -> tuple[float, float, float]: ...
+    def value(self) -> tuple[float, float, float]:
+        """
+        color value
+
+        :getter: Returns the color encoded in sRGB if :class:`Color.color_space <Color>`
+            is defined and not :class:`GenericColorSpace.Raw <GenericColorSpace>`,
+            otherwise return :class:`Color.value_raw <Color>`.
+        :type: Tuple[float, float, float]
+        """
     @property
-    def sRGB(self) -> tuple[float, float, float]: ...
+    def sRGB(self) -> tuple[float, float, float]:
+        """
+        color value in sRGB space
+
+        :getter: Returns the color value encoded in sRGB
+        :setter: Set the color value as sRGB encoded value
+        :type: Tuple[float, float, float]
+        :Raises: RuntimeError: if :class:`Color.color_space <Color>` is None
+        """
     @sRGB.setter
     def sRGB(self, value: tuple[float, float, float]) -> None: ...
     @property
-    def working(self) -> tuple[float, float, float]: ...
+    def working(self) -> tuple[float, float, float]:
+        """
+        color value in working space
+
+        :getter: Returns the color value encoded in working space
+        :setter: Set the color value as working space encoded value
+        :type: Tuple[float, float, float]
+        :Raises: RuntimeError: if :class:`Color.color_space <Color>` is None
+        """
     @working.setter
     def working(self, value: tuple[float, float, float]) -> None: ...

--- a/substance_painter/stubs/substance_painter-stubs/display.pyi
+++ b/substance_painter/stubs/substance_painter-stubs/display.pyi
@@ -4,48 +4,268 @@ from _typeshed import Incomplete
 
 from _substance_painter.display import ToneMappingFunction as ToneMappingFunction
 
-def get_environment_resource() -> substance_painter.resource.ResourceID | None: ...
-def set_environment_resource(new_env_map: substance_painter.resource.ResourceID) -> None: ...
-def get_color_lut_resource() -> substance_painter.resource.ResourceID | None: ...
-def set_color_lut_resource(new_color_lut: substance_painter.resource.ResourceID) -> None: ...
-def get_tone_mapping() -> ToneMappingFunction: ...
-def set_tone_mapping(new_tone_mapping: ToneMappingFunction) -> None: ...
+def get_environment_resource() -> substance_painter.resource.ResourceID | None:
+    """
+    Get the environment map resource of the active project.
+
+    Returns:
+        ResourceID: The environment map resource or None.
+
+    Raises:
+        ProjectError: If no project is opened.
+        ServiceNotFoundError: If Substance 3D Painter has not started all its
+            services yet.
+    """
+def set_environment_resource(new_env_map: substance_painter.resource.ResourceID) -> None:
+    """
+    Set the environment map resource of the active project.
+
+    Args:
+        new_env_map (ResourceID): The new environment map resource.
+
+    Raises:
+        ProjectError: If no project is opened.
+        TypeError: If ``new_env_map`` is not a ResourceID.
+        ResourceNotFoundError: If the environment map ``new_env_map`` is not found.
+        ServiceNotFoundError: If Substance 3D Painter has not started all its
+            services yet.
+    """
+def get_color_lut_resource() -> substance_painter.resource.ResourceID | None:
+    """
+    Get the color profile LUT resource of the active project.
+
+    Returns:
+        ResourceID:  The color profile LUT resource or None.
+
+    Raises:
+        ProjectError: If no project is opened.
+        ServiceNotFoundError: If Substance 3D Painter has not started all its
+            services yet.
+    """
+def set_color_lut_resource(new_color_lut: substance_painter.resource.ResourceID) -> None:
+    """
+    Set the color profile LUT resource of the active project.
+
+    Args:
+        new_color_lut (ResourceID): The new color profile LUT.
+
+    Raises:
+        ProjectError: If no project is opened.
+        TypeError: If ``new_color_lut`` is not a ResourceID.
+        ResourceNotFoundError: If the color profile ``new_color_lut`` is not found.
+        ServiceNotFoundError: If Substance 3D Painter has not started all its
+            services yet.
+    """
+def get_tone_mapping() -> ToneMappingFunction:
+    """
+    Get the tone mapping operator used to display the current project.
+
+    Note:
+        The tone mapping function is disabled when color management is enabled.
+        In that case trying to call get_tone_mapping will throw a RuntimeError.
+
+    Returns:
+        ToneMappingFunction: The tone mapping function currently used by
+            the project.
+
+    Raises:
+        RuntimeError: If the project is color managed.
+        ProjectError: If no project is opened.
+        ServiceNotFoundError: If Substance 3D Painter has not started all its
+            services yet.
+    """
+def set_tone_mapping(new_tone_mapping: ToneMappingFunction) -> None:
+    """
+    Set the tone mapping operator to display the current project.
+
+    Note:
+        The tone mapping function is disabled when color management is enabled.
+        In that case trying to call set_tone_mapping will throw a RuntimeError.
+
+    Args:
+        new_tone_mapping (ToneMappingFunction): The new tone mapping function
+            to use in the project.
+
+    Raises:
+        TypeError: If ``new_tone_mapping`` is not a ToneMappingFunction.
+        RuntimeError: If the project is color managed.
+        ProjectError: If no project is opened.
+        ServiceNotFoundError: If Substance 3D Painter has not started all its
+            services yet.
+    """
 
 from _substance_painter.display import CameraProjectionType as CameraProjectionType
 
 @dataclasses.dataclass
 class Camera:
+    '''
+    Allows the manipulation of the properties of an existing Camera.
+    Coordinates of the camera are defined in the scene space.
+
+    Example:
+        ::
+
+            import substance_painter.display
+            import substance_painter.project
+
+            substance_painter.project.open("C:/projects/MeetMat.spp")
+
+            # Get the dimensions of the scene
+            bounding_box = substance_painter.project.get_scene_bounding_box()
+
+            # Get the main camera
+            camera = substance_painter.display.Camera.get_default_camera()
+
+            # Update camera properties
+            camera.projection_type = substance_painter.display.CameraProjectionType.Perspective
+            # Move the camera away from the center of the scene
+            camera.position = [
+                bounding_box.center[0] + 15,
+                bounding_box.center[1],
+                bounding_box.center[2] + 15]
+            # Rotate the camera (45° of Y-axis)
+            camera.rotation = [0, 45, 0]
+            # Update the camera field of view (in degrees)
+            camera.field_of_view = 50
+
+    See also:
+        `Camera Settings documentation`_.
+        :func:`substance_painter.project.get_scene_bounding_box`
+
+        .. _Camera Settings documentation:
+            https://substance3d.adobe.com/documentation/spdoc/camera-settings-172818743.html
+    '''
     @staticmethod
-    def get_default_camera() -> Camera: ...
+    def get_default_camera() -> Camera:
+        """
+        Get the default camera.
+
+        Returns:
+            Camera: The default (main) camera.
+        Raises:
+            ProjectError: If no project is opened.
+            RuntimeError: If no camera has been found.
+        """
     @property
-    def position(self) -> list[float]: ...
+    def position(self) -> list[float]:
+        """
+        The position (x,y,z) of the camera.
+
+        :getter: Returns the position of the camera.
+        :setter: Sets the position of the camera.
+        :type: List[float]
+
+        Raises:
+            ProjectError: If no project is opened.
+        """
     @position.setter
     def position(self, position: list[float]) -> None: ...
     @property
-    def rotation(self) -> list[float]: ...
+    def rotation(self) -> list[float]:
+        """
+        The rotation (x,y,z) of the camera as Euler angles in degrees.
+
+        :getter: Returns the rotation of the camera.
+        :setter: Sets the rotation of the camera.
+        :type: List[float]
+
+        Raises:
+            ProjectError: If no project is opened.
+        """
     @rotation.setter
     def rotation(self, rotation: list[float]) -> None: ...
     @property
-    def field_of_view(self) -> float: ...
+    def field_of_view(self) -> float:
+        """
+        The field of view of the camera in degrees.
+        This value is only used if the ``CameraProjectionType`` is ``Perspective``.
+
+        :getter: Returns the field of view of the camera.
+        :setter: Sets the field of view of the camera. Value is clamped between 3 and 179.
+        :type: float
+
+        Note:
+            Modifing the field of view will change the focal length.
+
+        Raises:
+            ProjectError: If no project is opened.
+        """
     @field_of_view.setter
     def field_of_view(self, fov: float) -> None: ...
     @property
-    def focal_length(self) -> float: ...
+    def focal_length(self) -> float:
+        """
+        The focal length of the camera in mm.
+        This value is only used if the ``CameraProjectionType`` is ``Perspective``.
+
+        :getter: Returns the focal length of the camera.
+        :setter: Sets the focal length of the camera. Value is clamped between 1 and 500.
+        :type: float
+
+        Note:
+            Modifing the focal length will change the field of view.
+
+        Raises:
+            ProjectError: If no project is opened.
+        """
     @focal_length.setter
     def focal_length(self, focal_length: float) -> None: ...
     @property
-    def focus_distance(self) -> float: ...
+    def focus_distance(self) -> float:
+        """
+        The focus distance of the camera.
+        Defines the distance at which the focus point is located.
+
+        :getter: Returns the focus distance of the camera.
+        :setter: Sets the focus distance of the camera.
+            Value is clamped between 0 and 10 * scene radius.
+        :type: float
+
+        Raises:
+            ProjectError: If no project is opened.
+        """
     @focus_distance.setter
     def focus_distance(self, focus_distance: float) -> None: ...
     @property
-    def aperture(self) -> float: ...
+    def aperture(self) -> float:
+        """
+        The aperture of the camera. Defines how wide the Depth of Field will be.
+
+        :getter: Returns the lens radius.
+        :setter: Sets the lens radius. Value is clamped between 0 and 1 * scene radius.
+        :type: float
+
+        Raises:
+            ProjectError: If no project is opened.
+        """
     @aperture.setter
     def aperture(self, aperture: float) -> None: ...
     @property
-    def orthographic_height(self) -> float: ...
+    def orthographic_height(self) -> float:
+        """
+        The orthographic height of the camera.
+        This value is only used if the ``CameraProjectionType`` is ``Orthographic``.
+
+        :getter: Returns the orthographic height of the camera.
+        :setter: Sets the orthographic height of the camera.
+        :type: float
+
+        Raises:
+            ProjectError: If no project is opened.
+        """
     @orthographic_height.setter
     def orthographic_height(self, orthographic_height: float) -> None: ...
     @property
-    def projection_type(self) -> CameraProjectionType: ...
+    def projection_type(self) -> CameraProjectionType:
+        """
+        The projection type (perspective or orthographic) of the camera.
+
+        :getter: Returns the projection type of the camera.
+        :setter: Sets the projection type of the camera.
+        :type: CameraProjectionType
+
+        Raises:
+            ProjectError: If no project is opened.
+        """
     @projection_type.setter
     def projection_type(self, projection_type: CameraProjectionType) -> None: ...

--- a/substance_painter/stubs/substance_painter-stubs/event.pyi
+++ b/substance_painter/stubs/substance_painter-stubs/event.pyi
@@ -5,102 +5,243 @@ from typing import Union
 from substance_painter.async_utils import StopSource as StopSource
 from substance_painter.baking import BakingStatus as BakingStatus
 from substance_painter.export import ExportStatus as ExportStatus
+from substance_painter.resource import ReloadResourcesFilter as ReloadResourcesFilter, ResourceID as ResourceID
 from substance_painter.textureset import ChannelType as ChannelType
 from typing import Any, Callable
 
 @dataclasses.dataclass(frozen=True)
-class Event: ...
+class Event:
+    """Base event class."""
 
 @dataclasses.dataclass(frozen=True)
 class _TestEvent(Event):
+    """Event for testing purpose only.
+
+    This event is triggered by ``_substance_painter.event.trigger_test_event``.
+    """
     message: str
 
 @dataclasses.dataclass(frozen=True)
 class _DunamisEvent(Event):
-    workflow: str
-    subcategory: str
-    type: str
-    subtype: str
-    values: list[tuple[str, str]]
-    measures: list[tuple[str, Union[int, float]]]
-    children: list[type[Event]]  # type: ignore[valid-type]
+    """Event triggered when a dunamis event is sent.
+    """
+    json: str
 
 @dataclasses.dataclass(frozen=True)
-class ProjectOpened(Event): ...
+class _UpdateProjectResourcesEnded(Event):
+    """Event triggered when the update of project resources has ended.
+    """
 @dataclasses.dataclass(frozen=True)
-class ProjectCreated(Event): ...
+class ProjectOpened(Event):
+    """Event triggered when an existing project has been opened.
+    """
 @dataclasses.dataclass(frozen=True)
-class ProjectAboutToClose(Event): ...
+class ProjectCreated(Event):
+    """Event triggered when a new project has been created.
+    """
 @dataclasses.dataclass(frozen=True)
-class ProjectClosed(Event): ...
+class ProjectAboutToClose(Event):
+    """Event triggered just before closing the current project.
+    """
+@dataclasses.dataclass(frozen=True)
+class ProjectClosed(Event):
+    """Event triggered just before closing the current project.
+    """
 
 @dataclasses.dataclass(frozen=True)
 class ProjectAboutToSave(Event):
+    """Event triggered just before saving the current project.
+
+    :param file_path: The destination file.
+    """
     file_path: str
 
 @dataclasses.dataclass(frozen=True)
-class ProjectSaved(Event): ...
+class ProjectSaved(Event):
+    """Event triggered once the current project is saved.
+    """
 
 @dataclasses.dataclass(frozen=True)
 class ExportTexturesAboutToStart(Event):
+    """Event triggered just before a textures export.
+
+    :param textures: List of texture files
+        to be written to disk, grouped by stack (Texture Set name, stack name).
+    """
     textures: dict[tuple[str, str], list[str]]
 
 @dataclasses.dataclass(frozen=True)
 class ExportTexturesEnded(Event):
+    """Event triggered after textures export is finished.
+
+    :param status: Status code.
+    :param message: Human readable status message.
+    :param textures: List of texture files
+        written to disk, grouped by stack (Texture Set name, stack name).
+    """
     status: ExportStatus
     message: str
     textures: dict[tuple[str, str], list[str]]
 
 @dataclasses.dataclass(frozen=True)
 class ShelfCrawlingStarted(Event):
+    """Event triggered when a shelf starts reading the file system to discover
+    new resources.
+
+    :param shelf_name: Name of the shelf discovering resources.
+
+    See also:
+        :meth:`Shelf.is_crawling`.
+    """
     shelf_name: str
 
 @dataclasses.dataclass(frozen=True)
 class ShelfCrawlingEnded(Event):
+    """Event triggered when a shelf has finished discovering new resources and
+    loading their thumbnails.
+
+    :param shelf_name: Name of the shelf that has finished discovering resources.
+
+    See also:
+        :meth:`Shelf.is_crawling`.
+    """
     shelf_name: str
 
 @dataclasses.dataclass(frozen=True)
-class _ProjectEditionEntered(Event): ...
+class _ProjectEditionEntered(Event):
+    """Event triggered when the paint editor enter in edition mode.
+    """
 @dataclasses.dataclass(frozen=True)
-class _ProjectEditionLeft(Event): ...
+class _ProjectEditionLeft(Event):
+    """Event triggered when the paint editor leaves the editon mode.
+    """
 @dataclasses.dataclass(frozen=True)
-class ProjectEditionEntered(Event): ...
+class ProjectEditionEntered(Event):
+    """Event triggered when the project is fully loaded and ready to work with.
+
+    When edition is entered, it is for example possible to query/edit the project
+    properties, to bake textures or do project export.
+    """
 @dataclasses.dataclass(frozen=True)
-class ProjectEditionLeft(Event): ...
+class ProjectEditionLeft(Event):
+    """Event triggered when the current project can non longer be edited.
+    """
 
 @dataclasses.dataclass(frozen=True)
 class BusyStatusChanged(Event):
+    """Event triggered when Substance 3D Painter busy state changed.
+
+    :param busy: Whether Substance 3D Painter is busy now.
+
+    See also:
+        :func:`substance_painter.project.execute_when_not_busy`,
+        :func:`substance_painter.project.is_busy`.
+    """
     busy: bool
 
 @dataclasses.dataclass(frozen=True)
 class BakingProcessAboutToStart(Event):
+    """Event triggered when a baking is about to start.
+
+    :param stop_source: The baking stop source, can be compared with the StopSource
+        returned from the baking launch methods to identify the baking process.
+
+    See also:
+        :func:`substance_painter.baking.bake_async`
+        :func:`substance_painter.baking.bake_selected_textures_async`
+    """
     stop_source: StopSource
 
 @dataclasses.dataclass(frozen=True)
 class BakingProcessProgress(Event):
+    """Event triggered when baking process progress changes.
+
+    :param progress: The baking progress, between [0.0, 1.0].
+
+    See also:
+        :func:`substance_painter.baking.bake_async`
+        :func:`substance_painter.baking.bake_selected_textures_async`
+    """
     progress: float
 
 @dataclasses.dataclass(frozen=True)
 class BakingProcessEnded(Event):
+    """Event triggered after baking is finished.
+
+    :param status: Status of the baking process.
+
+    See also:
+        :func:`substance_painter.baking.bake_async`
+        :func:`substance_painter.baking.bake_selected_textures_async`
+    """
     status: BakingStatus
 
 @dataclasses.dataclass(frozen=True)
-class _LayerStacksModelDataChanged(Event): ...
+class _LayerStacksModelDataChanged(Event):
+    """Private event triggered whenever the status of the Layer Stacks changes."""
 @dataclasses.dataclass(frozen=True)
-class LayerStacksModelDataChanged(Event): ...
+class LayerStacksModelDataChanged(Event):
+    """
+    Event triggered whenever the status of the Layer Stacks changes.
+
+    See also:
+        :mod:`substance_painter.layerstack`
+    """
 
 @dataclasses.dataclass(frozen=True)
 class EngineComputationsStatusChanged(Event):
+    """
+    Event triggered whenever the status of the engine computations changes.
+
+    See also:
+        :func:`substance_painter.application.engine_computations_status`
+    """
     engine_computations_enabled: bool
+
+@dataclasses.dataclass(frozen=True)
+class GraphicalUserInterfaceStarted(Event):
+    """
+    Event triggered when the GUI has finished to initialize itself.
+
+    If you want to make sure every widget part of the UI is instanciated,
+    wait for this event before anything.
+    """
 
 from _substance_painter.event import TextureStateEventAction as TextureStateEventAction
 
 @dataclasses.dataclass(frozen=True)
 class TextureStateEvent(Event):
+    """Event triggered when a document texture is added, removed or updated.
+
+    :param action: Performed action (add, remove, update).
+    :param stack_id: The stack the texture bellongs to, can be used to create a
+        :class:`substance_painter.textureset.Stack` instance.
+    :param tile_indices: The uv tile indices.
+    :param channel_type: The document channel type.
+    :param cache_key: The texture current cache key. Those cache keys are persistent across
+        sessions.
+    """
     @staticmethod
-    def cache_key_invalidation_throttling_period() -> datetime.timedelta: ...
+    def cache_key_invalidation_throttling_period() -> datetime.timedelta:
+        """Get the minimum duration between two texture update events (for a given texture).
+
+        Returns:
+            datetime.timedelta: The minimum duration between two update events.
+        """
     @staticmethod
-    def set_cache_key_invalidation_throttling_period(period: datetime.timedelta) -> None: ...
+    def set_cache_key_invalidation_throttling_period(period: datetime.timedelta) -> None:
+        """Set the minimum duration between two texture update events (for a given texture).
+
+        Warning: this setting is global and every work made in a callback associated to this event
+        may greatly hurt the painting experience.
+
+        Args:
+            period (datetime.timedelta): The minimum duration between two update events, can't
+                be lower than 500ms.
+
+        Raises:
+            ValueError: If period is below 500ms.
+        """
     action: TextureStateEventAction
     stack_id: int
     tile_indices: tuple[int, int]
@@ -109,19 +250,110 @@ class TextureStateEvent(Event):
 
 @dataclasses.dataclass(frozen=True)
 class CameraPropertiesChanged(Event):
+    """Event triggered when the camera properties change.
+
+    See also:
+        :class:`substance_painter.display.Camera`
+    """
     camera_id: int
 
+@dataclasses.dataclass(frozen=True)
+class ReloadResourcesStarted(Event):
+    """Event triggered when a resource reload operation has started.
+
+    :param filter: The filter object used to choose the resources that are being reloaded.
+
+    See also:
+        :func:`substance_painter.resource.reload_modified_resources_async`
+    """
+    filter: ReloadResourcesFilter
+
+@dataclasses.dataclass(frozen=True)
+class ReloadedResourceResult:
+    """Per resource result of a succesfull resource reload operation.
+
+    :param old_resource_id: The ResourceID of the resource that was asked to be reloaded.
+    :param new_resource_id: The ResourceID of the newly added resource.
+
+    See also:
+        :class:`ReloadResourcesEnded`
+        :func:`substance_painter.resource.reload_modified_resources_async`
+    """
+    old_resource_id: ResourceID
+    new_resource_id: ResourceID
+
+@dataclasses.dataclass(frozen=True)
+class ReloadedResourceError:
+    """Per resource result of an unsuccesfull resource reload operation.
+
+    :param resource_id: The ResourceID of the resource that was asked to be reloaded.
+    :param error_msg: The error message detailing what prevented the resource from being reloaded.
+
+    See also:
+        :class:`ReloadResourcesEnded`
+        :func:`substance_painter.resource.reload_modified_resources_async`
+    """
+    resource_id: ResourceID
+    error_msg: str
+
+@dataclasses.dataclass(frozen=True)
+class ReloadResourcesEnded(Event):
+    """Event triggered when a resource reload operation has completed.
+
+    :param filter: The filter object used to choose which resources to reload.
+    :param reloaded_resources: The list of resources that were successfully reloaded.
+    :param resource_errors: The list of resources that could not be reloaded, along with the
+        corresponding reason.
+
+    See also:
+        :func:`substance_painter.resource.reload_modified_resources_async`
+    """
+    filter: ReloadResourcesFilter
+    reloaded_resources: list[ReloadedResourceResult]
+    resource_errors: list[ReloadedResourceError]
+
 class _ProjectEditionStateEventsGenerator:
+    """Generate public 'ProjectEditionEntered' and 'ProjectEditionLeft' events."""
     class _State(enum.Enum):
+        """Internal state."""
         EDITION_STOPPED = 1
         PRE_EDITION_STARTED = 2
         EDITION_STARTED = 3
     def __init__(self, dispatcher) -> None: ...
 
 class Dispatcher:
+    """The Event Dispatcher."""
     def __init__(self) -> None: ...
-    def connect(self, event_cls: type[Event], callback: Callable[[Event], Any]) -> None: ...
-    def connect_strong(self, event_cls: type[Event], callback: Callable[[Event], Any]) -> None: ...
-    def disconnect(self, event_cls: type[Event], callback: Callable[[Event], Any]) -> None: ...
+    def connect(self, event_cls: type[Event], callback: Callable[[Event], Any]) -> None:
+        """Connect a callback to handle the given event type.
+
+        The callback is stored as a weak reference, it is automatically disconnected
+        once the callback gets garbage collected.
+
+        Args:
+            event_cls (Type[Event]): An event class.
+            callback (Callable[[Event], Any]): A method or a bound method that will be called when
+                an instance of the given event class is triggered.
+        """
+    def connect_strong(self, event_cls: type[Event], callback: Callable[[Event], Any]) -> None:
+        """Connect a callback to handle the given event type.
+
+        The callback is stored as a strong reference, it is never automatically disconnected.
+
+        Args:
+            event_cls (Type[Event]): An event class.
+            callback (Callable[[Event], Any]): A method or a bound method that will be called when
+                an instance of the given event class is triggered.
+        """
+    def disconnect(self, event_cls: type[Event], callback: Callable[[Event], Any]) -> None:
+        """Disconnect a previously connected callback.
+
+        This method can be called to explicitly disconnect a callback.
+
+        Args:
+            event_cls (Type[Event]): An event class.
+            callback (Callable[[Event], Any]): A method or a bound method that has been connected
+                to the given event class.
+        """
 
 DISPATCHER: Dispatcher

--- a/substance_painter/stubs/substance_painter-stubs/export.pyi
+++ b/substance_painter/stubs/substance_painter-stubs/export.pyi
@@ -5,40 +5,465 @@ from _typeshed import Incomplete
 
 from _substance_painter.export import ExportStatus as ExportStatus
 
-def list_project_textures(json_config: dict) -> dict[tuple[str, str], list[str]]: ...
+def list_project_textures(json_config: dict) -> dict[tuple[str, str], list[str]]:
+    """
+    Get list of textures that would be exported according to the given JSON configuration.
+
+    Args:
+        json_config (dict): JSON object representing the export configuration to be used.
+            See `JSON configuration <#full-json-config-dict-possibilities>`_.
+
+    Returns:
+        typing.Dict[typing.Tuple[str, str], typing.List[str]]: List of texture files
+        that would be exported, grouped by stack (Texture Set name, stack name).
+
+    Raises:
+        ProjectError: If no project is opened.
+        ValueError: If ``json_config`` is ill-formed, or is invalid in the context
+            of the current project.
+            Contains a human readable message.
+
+    See also:
+        :func:`export_project_textures`.
+    """
 
 @dataclasses.dataclass(frozen=True)
 class TextureExportResult:
+    """
+    Result of the export textures process
+
+    :param status: Status code.
+    :param message: Human readable status message.
+    :param textures: List of texture files
+            written to disk, grouped by stack (Texture Set name, stack name).
+    """
     status: ExportStatus
     message: str
     textures: dict[tuple[str, str], list[str]]
 
-def export_project_textures(json_config: dict) -> TextureExportResult: ...
-def get_default_export_path() -> str: ...
+def export_project_textures(json_config: dict) -> TextureExportResult:
+    '''
+    Export document textures according to the given JSON configuration. The
+    return value contains the list of texture files written to disk.
+
+    The status of the return value can never be `Error`, any error causing the
+    export to fail will raise an exception instead. However if the export fails,
+    the associated event `ExportTextureEnded` will indeed receive `Error` as a
+    status.
+    If the export is cancelled by the user, the function return value will have
+    the status `Cancelled` and contain the list of texture files written to disk
+    before export was cancelled.
+
+    Args:
+        json_config (dict): JSON object representing the export configuration to be used.
+            See `JSON configuration <#full-json-config-dict-possibilities>`_.
+
+    Returns:
+        TextureExportResult: Result of the export process.
+
+    Raises:
+        ProjectError: If no project is opened.
+        ValueError: If ``json_config`` is ill-formed, or is invalid in the context
+            of the current project. Contains a human readable message detailing
+            the problem.
+
+    See also:
+        :class:`substance_painter.event.ExportTexturesAboutToStart`,
+        :class:`substance_painter.event.ExportTexturesEnded`.
+
+
+    Example:
+    ::
+
+        import substance_painter.export
+
+        # Open a project we want to export from (see substance_painter.project
+        # for details). This step is not necessary if there is already a project
+        # opened in Substance 3D Painter.
+        import substance_painter.project
+        substance_painter.project.open("C:/projects/MeetMat.spp")
+
+        # Choose an export preset to use (see substance_painter.resource). This
+        # step is not mandatory as you can alternatively describe the export
+        # preset entirely in JSON (see the full example at the bottom of the
+        # page).
+        # Note: in this example the preset file format and bit depth are
+        # overridden below for \'03_Base\', but otherwise follow the export preset
+        # configuration.
+        import substance_painter.resource
+        export_preset = substance_painter.resource.ResourceID(
+            context="starter_assets", name="Arnold (AiStandard)")
+
+        # Set the details of the export (a comprehensive example of all the
+        # configuration options is presented at the bottom of the page):
+        export_config = {
+            "exportShaderParams": False,
+            "exportPath": "C:/export",
+            "defaultExportPreset" : export_preset.url(),
+            "exportList": [
+                {
+                    "rootPath": "01_Head"
+                },
+                {
+                    "rootPath": "02_Body"
+                },
+                {
+                    "rootPath": "03_Base"
+                }],
+            "exportParameters": [
+                # No filters: those parameters apply to all exported maps
+                {
+                    "parameters": {
+                        "dithering": True,
+                        "paddingAlgorithm": "infinite"
+                    }
+                },
+                # Force file format and bitDepth for all maps in \'03_Base\'
+                {
+                    "filter": {"dataPaths": ["03_Base"]},
+                    "parameters": {
+                        "fileFormat" : "png",
+                        "bitDepth" : "8"
+                    }
+                },
+                # Force 2K size for all maps in \'01_Head\'
+                {
+                    "filter": {"dataPaths": ["01_Head"]},
+                    "parameters": {
+                        "sizeLog2": 11
+                    }
+                }]
+            }
+
+        # Display the list of textures that should be exported, according to the
+        # configuration:
+        export_list = substance_painter.export.list_project_textures(export_config)
+        for k,v in export_list.items():
+            print("Stack {0}:".format(k))
+            for to_export in v:
+                print(to_export)
+
+        # Actual export operation:
+        export_result = substance_painter.export.export_project_textures(export_config)
+
+        # In case of error, display a human readable message:
+        if export_result.status != substance_painter.export.ExportStatus.Success:
+            print(export_result.message)
+
+        # Display the details of what was exported:
+        for k,v in export_result.textures.items():
+            print("Stack {0}:".format(k))
+            for exported in v:
+                print(exported)
+
+    See also:
+        :mod:`substance_painter.project`,
+        :mod:`substance_painter.resource`,
+        `Export documentation`_.
+
+    .. _Export documentation:
+        https://www.adobe.com/go/painter-export
+    '''
+def get_default_export_path() -> str:
+    """
+    Get the application default export path used for exporting textures.
+    This path does not depend on the project and is the default value used when
+    creating a new project.
+
+    Returns:
+        str: The default export path of the application.
+    """
 
 @dataclasses.dataclass(frozen=True)
 class PredefinedExportPreset:
+    '''
+    An export preset (output template) controls the behavior of the export process.
+    A predefined preset has a dynamic list of maps exported depending on the project and can have
+    pre/post processes that generates custom data (e.g. glTF).
+    This type of export preset is embedded in the application and cannot be edited.
+
+    Example:
+    ::
+
+        import substance_painter.export
+        import substance_painter.project
+        import substance_painter.textureset
+
+        # A project needs to be opened to introspect the output maps of a predefined export preset
+        substance_painter.project.open("C:/projects/MeetMat.spp")
+
+        # Retrieve all predefined export presets
+        predefined_presets = substance_painter.export.list_predefined_export_presets()
+
+        # Retrieve data of the first preset
+        predefined_preset = predefined_presets[0]
+        print("Name: " + predefined_preset.name + ", url: " + predefined_preset.url)
+        stack = substance_painter.textureset.get_active_stack()
+        print(predefined_preset.list_output_maps(stack))
+
+    :param name: The name of the preset.
+    :param url: The URL of the preset.
+
+    See also:
+        `Predefined presets documentation`_.
+
+    .. _Predefined presets documentation:
+        https://helpx.adobe.com/substance-3d-painter/getting-started/export/export-presets/predefined-presets.html
+    '''
     name: str
     url: str
-    def list_output_maps(self, stack: substance_painter.textureset.Stack) -> list: ...
+    def list_output_maps(self, stack: substance_painter.textureset.Stack) -> list:
+        """
+        Get the list of output maps based on the channels available on the given stack. The output
+        maps have the same format as the ``maps`` list in the JSON configuration.
 
-def list_predefined_export_presets() -> list[PredefinedExportPreset]: ...
+        Args:
+            stack (substance_painter.textureset.Stack): The stack to get the output maps from.
+
+        Returns:
+            dict:
+                The list of output maps on the channels available on the given stack. The output
+                maps have the same format as the ``maps`` list in the JSON configuration.
+                See `JSON configuration <#full-json-config-dict-possibilities>`_.
+
+        Raises:
+            ProjectError: If no project is opened.
+            ValueError: If the given stack is invalid.
+
+        See also:
+            :mod:`substance_painter.textureset`
+        """
+
+def list_predefined_export_presets() -> list[PredefinedExportPreset]:
+    """
+    Get the list of predefined export presets (output templates).
+
+    Returns:
+        List[PredefinedExportPreset]: The list of predefined export presets.
+
+    See also:
+        Example in :class:`PredefinedExportPreset`
+    """
 
 @dataclasses.dataclass(frozen=True)
 class ResourceExportPreset:
-    resource_id: substance_painter.resource.ResourceID
-    def list_output_maps(self) -> list: ...
+    '''
+    An export preset (output template) controls the behavior of the export process.
+    A shelf export preset is a resource with the ``Export``
+    :class:`substance_painter.resource.Type`. It can be modified by the user via the UI.
 
-def list_resource_export_presets() -> list[ResourceExportPreset]: ...
+    Example:
+    ::
+
+        import substance_painter.export
+        import substance_painter.project
+
+        substance_painter.project.open("C:/projects/MeetMat.spp")
+
+        # Retrieve all resource export presets
+        resource_presets = substance_painter.export.list_resource_export_presets()
+
+        # Retrieve PBR Metalllic Roughness export preset
+        preset = ""
+        match = "PBR Metallic Roughness"
+        for resource_preset in resource_presets :
+            if resource_preset.resource_id.name == "PBR Metallic Roughness":
+                print("Name: {}, url: {}".format(
+                    resource_preset.resource_id.name,
+                    resource_preset.resource_id.url()))
+                preset = resource_preset
+                break
+
+        maps = preset.list_output_maps()
+        # Add new output map 2D View
+        maps.append({
+            \'channels\': [{
+                \'destChannel\': \'R\',
+                \'srcChannel\': \'R\',
+                \'srcMapName\': \'View_2D\',
+                \'srcMapType\': \'virtualMap\',
+                \'srcPath\': \'\'
+            }, {
+                \'destChannel\': \'G\',
+                \'srcChannel\': \'G\',
+                \'srcMapName\': \'View_2D\',
+                \'srcMapType\': \'virtualMap\',
+                \'srcPath\': \'\'
+            }, {
+                \'destChannel\': \'B\',
+                \'srcChannel\': \'B\',
+                \'srcMapName\': \'View_2D\',
+                \'srcMapType\': \'virtualMap\',
+                \'srcPath\': \'\'
+            }, {
+                \'destChannel\': \'A\',
+                \'srcChannel\': \'A\',
+                \'srcMapName\': \'View_2D\',
+                \'srcMapType\': \'virtualMap\',
+                \'srcPath\': \'\'
+            }],
+            \'fileName\':
+            \'$mesh_$textureSet_2D_View\',
+            \'parameters\': {
+                \'bitDepth\': \'8\',
+                \'dithering\': False,
+                \'fileFormat\': \'png\'
+            }
+        })
+
+        # Create a new preset
+        newPresetName = "PBR Metallic Roughness 2D View"
+        newPreset = {
+            "name": newPresetName,
+            "maps": maps
+        }
+        # Use the preset in the export configuration
+        export_config = {
+            "exportShaderParams": False,
+            "exportPath": "C:/export",
+            "defaultExportPreset" : newPresetName,
+            "exportPresets": [newPreset],
+            "exportList": [
+                {
+                    "rootPath": "01_Head"
+                },
+                {
+                    "rootPath": "02_Body"
+                },
+                {
+                    "rootPath": "03_Base"
+                }],
+            "exportParameters": [
+                {
+                    "parameters": {
+                        "dithering": True,
+                        "paddingAlgorithm": "infinite"
+                    }
+                }]
+            }
+
+        substance_painter.export.export_project_textures(export_config)
+
+    :param resource_id: The resource ID of the export preset.
+
+    See also:
+        :mod:`substance_painter.resource`,
+        `Creating export presets`_.
+
+    .. _Creating export presets:
+        https://helpx.adobe.com/substance-3d-painter/getting-started/export/creating-export-presets.html
+    '''
+    resource_id: substance_painter.resource.ResourceID
+    def list_output_maps(self) -> list:
+        """
+        Get the list of output maps for the given preset. The output maps have the same format as
+        the ``maps`` list in the JSON configuration.
+
+        Returns:
+            dict:
+                The list of output maps for the given preset. The output maps have the same format
+                as the ``maps`` list in the JSON configuration.
+                See `JSON configuration <#full-json-config-dict-possibilities>`_.
+
+        Raises:
+            ValueError: If the given preset is invalid.
+        """
+
+def list_resource_export_presets() -> list[ResourceExportPreset]:
+    """
+    Get the list of export presets (output templates). This list contains all export presets
+    available in the shelves (presets provided by default and custom ones if any).
+
+    Returns:
+        List[ResourceExportPreset]: The list of export presets.
+
+    See also:
+        Example in :class:`ResourceExportPreset`
+    """
 
 from _substance_painter.export import MeshExportOption as MeshExportOption
 
-def scene_is_triangulated() -> bool: ...
-def scene_has_tessellation() -> bool: ...
+def scene_is_triangulated() -> bool:
+    """
+    Check if the scene has only triangles (polygons with only 3 sides).
+
+    Returns:
+        bool: True if the current scene has only triangles, False otherwise.
+
+    Raises:
+        ProjectError: If no project is opened.
+    """
+def scene_has_tessellation() -> bool:
+    """
+    Check if the scene has displacement/tessellation enabled.
+
+    Returns:
+        bool: True if the current scene has displacement/tessellation, False otherwise.
+
+    Raises:
+        ProjectError: If no project is opened.
+    """
 
 @dataclasses.dataclass(frozen=True)
 class MeshExportResult:
+    """
+    Result of the export mesh process
+
+    :param status: Status code.
+    :param message: Human readable status message.
+    """
     status: ExportStatus
     message: str
 
-def export_mesh(file_path: str, option: MeshExportOption) -> MeshExportResult: ...
+def export_mesh(file_path: str, option: MeshExportOption) -> MeshExportResult:
+    '''
+    Export the current mesh to the given file path.
+
+    Args:
+        file_path (string): The complete file path where to export the mesh. The file format is
+            deduced from the extension.
+            Supported extensions are: ``.usd``, ``.obj``, ``.fbx``, ``.dae``, ``.ply``, ``.gltf``.
+        option (MeshExportOption): The export option to use.
+
+    Returns:
+        MeshExportResult: Result of the export process.
+
+    Raises:
+        ProjectError: If no project is opened.
+        ValueError: If ``file_path`` or ``option`` are invalid in the context
+            of the current project. Contains a human readable message detailing
+            the problem.
+
+    Example:
+    ::
+
+        import substance_painter.export
+
+        # Open a project we want to export from (see substance_painter.project
+        # for details). This step is not necessary if there is already a project
+        # opened in Substance 3D Painter.
+        import substance_painter.project
+        substance_painter.project.open("C:/projects/MeetMat.spp")
+
+        # Choose an export option to use
+        export_option = substance_painter.export.MeshExportOption.BaseMesh
+        if not substance_painter.export.scene_is_triangulated():
+            export_option = substance_painter.export.MeshExportOption.TriangulatedMesh
+        if substance_painter.export.scene_has_tessellation():
+            export_option = substance_painter.export.MeshExportOption.TessellationNormalsBaseMesh
+
+        # Actual export mesh operation:
+        filename = "C:/projects/MeetMat.obj"
+        export_result = substance_painter.export.export_mesh(filename, export_option)
+
+        # In case of error, display a human readable message:
+        if export_result.status != substance_painter.export.ExportStatus.Success:
+            print(export_result.message)
+
+    See also:
+        :mod:`substance_painter.project`,
+        `Export documentation`_.
+
+    .. _Export documentation:
+        https://www.adobe.com/go/painter-export
+    '''

--- a/substance_painter/stubs/substance_painter-stubs/js.pyi
+++ b/substance_painter/stubs/substance_painter-stubs/js.pyi
@@ -1,1 +1,16 @@
-def evaluate(js_code: str) -> str: ...
+def evaluate(js_code: str) -> str:
+    """
+    Evaluate a JavaScript expression.
+    The JavaScript API is described in dedicated help accessible via the
+    ``Help > Scripting documentation > JavaScript API`` menu found in
+    `Substance 3D Painter` application.
+
+    Args:
+        js_code (str): The block of JavaScript code to be evaluated.
+
+    Returns:
+        str: The JSON formated result of the evaluation.
+
+    Raises:
+        RuntimeError: If the JavaScript exception evaluation returns an error.
+    """

--- a/substance_painter/stubs/substance_painter-stubs/layerstack.pyi
+++ b/substance_painter/stubs/substance_painter-stubs/layerstack.pyi
@@ -15,6 +15,19 @@ from _substance_painter.layerstack import BlendingMode as BlendingMode
 from _substance_painter.layerstack import NodeType as NodeType
 
 class NodeStack(Enum):
+    """
+    Indicate which node stack you want to insert in.
+
+    Members:
+
+    ================= ===========================
+    Name              Description
+    ================= ===========================
+    ``Substack``      Insert in the substack of a node (only valid for a Folder node).
+    ``Content``       Insert in the content stack of the node.
+    ``Mask``          Insert in the mask stack of the node.
+    ================= ===========================
+    """
     Substack = ...
     Content = ...
     Mask = ...
@@ -23,6 +36,15 @@ from _substance_painter.layerstack import MaskBackground as MaskBackground
 from _substance_painter.layerstack import ColorSelectionBackgroundColor as ColorSelectionBackgroundColor
 from _substance_painter.layerstack import GeometryMaskType as GeometryMaskType
 from _substance_painter.layerstack import ProjectionMode as ProjectionMode
+
+def is_3d_projection_mode(projection_mode: ProjectionMode) -> bool:
+    """
+    Check if the projection mode is a 3D projection.
+
+    :param projection_mode: Projection mode to check.
+    :returns: True if the current projection mode is a 3D projection.
+    """
+
 from _substance_painter.layerstack import FilteringMode as FilteringMode
 from _substance_painter.layerstack import UVWrapMode as UVWrapMode
 from _substance_painter.layerstack import ShapeCropMode as ShapeCropMode
@@ -30,88 +52,635 @@ from _substance_painter.layerstack import ScaleMode as ScaleMode
 from _substance_painter.layerstack import CompareMaskEffectOperand as CompareMaskEffectOperand
 from _substance_painter.layerstack import CompareMaskEffectOperation as CompareMaskEffectOperation
 from _substance_painter.layerstack import SelectionType as SelectionType
+from _substance_painter.layerstack import SymmetryAxis as SymmetryAxis  # type: ignore[attr-defined]
+from _substance_painter.layerstack import SymmetryMode as SymmetryMode  # type: ignore[attr-defined]
 
 class ScopedModification:
+    '''
+    :class:`ScopedModification` can be used to group many layerstack modification calls
+    in a single undoable command.
+
+    `name` will be displayed in the software history.
+
+    This object is usefull to:
+       * Avoid poluting the history by grouping logically layerstack
+         modifications behind a unique name.
+       * The computation will only happen when we leave the ``with`` statement
+         meaning that we don\'t waste time computing intermedietary result that we
+         don\'t need.
+
+    This object is a context manager usable with the python ``with`` statement
+
+    Example:
+        .. code-block:: python
+
+            import substance_painter as sp
+
+            def insert_many_fills():
+                # Insert many layers inside the current texture set layer stack
+                # and set their projection mode to tri-planar
+                insert_position = sp.layerstack.InsertPosition.from_textureset_stack(
+                    sp.textureset.get_active_stack())
+                fill = sp.layerstack.insert_fill(insert_position)
+                fill.set_projection_mode(sp.layerstack.ProjectionMode.Triplanar)
+                fill = sp.layerstack.insert_fill(insert_position)
+                fill.set_projection_mode(sp.layerstack.ProjectionMode.Triplanar)
+                fill = sp.layerstack.insert_fill(insert_position)
+                fill.set_projection_mode(sp.layerstack.ProjectionMode.Triplanar)
+
+            # Calling this method will generate many history entries (1 for each
+            # inserted fill and 1 for each projection mode update) and
+            # Substance Painter will compute the textures each time a modification
+            # happens.
+            #
+            # Expected history:
+            #   * Add fill
+            #   * Update projection mode
+            #   * Add fill
+            #   * Update projection mode
+            #   * Add fill
+            #   * Update projection mode
+            #
+            # Potential texture update in the viewport: 6 (one for each modification)
+            insert_many_fills()
+
+            # With the ScopedModification below, only one entry will be added to Painter
+            # history. A single undo will remove all the fill inserted inside the
+
+            # Calling this method inside a ScopedModification will only generate one history
+            # entry and Substance Painter will compute the textures only once.
+            #
+            # Expected history:
+            #   * Insert many layers
+            #
+            # Potential texture update in the viewport: 1
+            with sp.layerstack.ScopedModification("Insert many layers"):
+                insert_many_fills()
+
+    '''
     name: Incomplete
     def __init__(self, name) -> None: ...
     def __enter__(self) -> None: ...
     def __exit__(self, exc_type: type[BaseException] | None, exc_value: BaseException | None, exc_traceback: types.TracebackType | None) -> None: ...
 
 class FillParamsEditorMixin:
-    def get_projection_mode(self) -> ProjectionMode: ...
-    def set_projection_mode(self, projection_mode: ProjectionMode): ...
-    def get_projection_parameters(self) -> ProjectionParams | None: ...
-    def set_projection_parameters(self, projection_parameters: ProjectionParams): ...
+    """
+    A mixin allowing manipulation of this fill parameters.
+
+    :meta private:
+    """
+    def get_projection_mode(self) -> ProjectionMode:
+        """
+        Get the current projection mode.
+
+        :returns: The current projection mode.
+        """
+    def set_projection_mode(self, projection_mode: ProjectionMode):
+        """
+        Switch to a new projection mode.
+
+        :param projection_mode: The new projection mode.
+        :raises ValueError: If the projection mode is not supported in the current context.
+        """
+    def get_projection_parameters(self) -> ProjectionParams | None:
+        """
+        Get the current projection parameters.
+        Each kind of Projection Mode returns a specific kind of ProjectionParams, supporting a
+        different set of features.
+        `Fill` mode support no parameters, and returns None.
+
+        :returns: The current projection parameters, or None for `Fill`.
+
+        See also:
+            :meth:`get_projection_mode`,
+            `Fill projections documentation`_
+        """
+    def set_projection_parameters(self, projection_parameters: ProjectionParams):
+        """
+        Set projection parameters and update the current projection mode accordingly.
+
+        :param projection_parameters: The new parameters to apply.
+        :raises ValueError: If the projection parameters are not supported in the current context.
+
+        See also:
+            :meth:`get_projection_parameters`,
+            `Fill projections documentation`_
+        """
+    def is_symmetry_enabled(self) -> bool:
+        """
+        Check if symmetry is enabled.
+        Symmetry is only available for 3D projection modes. See
+        :func:`substance_painter.layerstack.is_3d_projection_mode`.
+
+        :raises ValueError: If the symmetry is not supported in the current context.
+        :returns: True if symmetry is enabled, False otherwise.
+        """
+    def set_symmetry_enabled(self, enabled: bool):
+        """
+        Set the symmetry enabled state.
+        Symmetry is only available for 3D projection modes. See
+        :func:`substance_painter.layerstack.is_3d_projection_mode`.
+
+        :param enabled: True to enable symmetry, False to disable it.
+        :raises ValueError: If the symmetry is not supported in the current context.
+        """
+    def get_symmetry_parameters(self) -> SymmetryParams:
+        """
+        Get the current symmetry parameters.
+        Each kind of symmetry mode returns a specific kind of SymmetryParams, supporting a
+        different set of features.
+        Symmetry is only available for 3D projection modes. See
+        :func:`substance_painter.layerstack.is_3d_projection_mode`.
+
+        :raises ValueError: If the symmetry is not supported in the current context.
+        :returns: The current symmetry parameters.
+        """
+    def set_symmetry_parameters(self, symmetry_parameters: SymmetryParams):
+        """
+        Set the symmetry parameters and update the current symmetry mode accordingly.
+        This does not enable symmetry. Explicitely use :meth:`set_symmetry_enabled` to enable it.
+        Symmetry is only available for 3D projection modes. See
+        :func:`substance_painter.layerstack.is_3d_projection_mode`.
+
+        Example to set and enable radial symmetry::
+
+            symmetry_parameters = sp.layerstack.RadialSymmetryParams()
+            symmetry_parameters.axis = sp.layerstack.SymmetryAxis.X
+            symmetry_parameters.flip_u = False
+            symmetry_parameters.flip_v = True
+            symmetry_parameters.axis_position = [0, 0.1, -0.1]
+            symmetry_parameters.angle_span = 70
+            symmetry_parameters.count = 10
+            my_layer.set_symmetry_parameters(symmetry_parameters)
+            my_layer.set_symmetry_enabled(True)
+
+        :param symmetry_parameters: The new parameters to apply.
+        :raises ValueError: If the symmetry is not supported in the current context.
+        """
 
 class Node(ReadOnlyUid):
+    """
+    Abstract class to manipulate common properties of a layer stack node.
+    Each node is identified by a node uid.
+
+    Calling methods of a Node with an incorrect `uid` throws a ValueError.
+    This could happen when instanciating a Node providing its `uid` by hand, or when the Node no
+    longer refers to existing data in the Layer Stack.
+
+    See also:
+        :func:`substance_painter.layerstack.get_node_by_uid`,
+        :ref:`layerstack_edition_insertion` section.
+    """
     def __eq__(self, other): ...
     def __hash__(self): ...
-    def get_type(self) -> NodeType: ...
-    def get_texture_set(self) -> TextureSet: ...
-    def is_visible(self) -> bool: ...
-    def set_visible(self, visible: bool): ...
-    def get_name(self) -> str: ...
-    def set_name(self, name: str): ...
-    def is_in_mask_stack(self) -> bool: ...
-    def has_blending(self) -> bool: ...
-    def get_blending_mode(self, channel: ChannelType | None = None) -> BlendingMode: ...
-    def set_blending_mode(self, blending_mode: BlendingMode, channel: ChannelType | None = None): ...
-    def get_opacity(self, channel: ChannelType | None = None) -> float: ...
-    def set_opacity(self, opacity: float, channel: ChannelType | None = None): ...
-    def get_stack(self) -> Stack: ...
-    def get_parent(self) -> Node: ...
-    def get_next_sibling(self) -> Node: ...
-    def get_previous_sibling(self) -> Node: ...
+    def get_type(self) -> NodeType:
+        """
+        Check the type of the node.
+
+        :returns: The node type.
+        """
+    def get_texture_set(self) -> TextureSet:
+        """
+        Get the TextureSet this node belongs to.
+
+        :returns: the TextureSet this node belongs to.
+        """
+    def is_visible(self) -> bool:
+        """
+        Check whether this node is rendered.
+
+        :returns: Whether this node is rendered.
+        """
+    def set_visible(self, visible: bool):
+        """
+        Enable this node for rendering.
+
+        :param visible: Whether to enable this node for rendering.
+        """
+    def get_name(self) -> str:
+        """
+        Get the name assigned to this Node.
+
+        :returns: The Node name.
+        """
+    def set_name(self, name: str):
+        """
+        Change this node name.
+
+        :param name: New name to use.
+        """
+    def is_in_mask_stack(self) -> bool:
+        """
+        Check whether this node is part of a mask stack.
+
+        :returns: Whether this node is part of a mask stack.
+        """
+    def has_blending(self) -> bool:
+        """
+        Check whether this node supports blending information (blending mode + opacity).
+        The blending might be per Channel Type for regular nodes, or monochannel for nodes
+        inside a mask stack.
+
+        :returns: Whether this node supports blending information.
+
+        See also:
+            :meth:`is_in_mask_stack`,
+            `Blending modes documentation`_
+        """
+    def get_blending_mode(self, channel: ChannelType | None = None) -> BlendingMode:
+        """
+        Get the blending mode for a Node.
+        If the node is not in a mask stack, a Channel Type must be provided.
+        If the node is in a mask stack, Channel Type must be None.
+
+        :param channel: Channel Type to query or None for mask nodes.
+        :raises ValueError: If the node has blending information per Channel Type and no Channel
+                Type is provided, or if the node has blending information without Channel Type and
+                a Channel Type is provided.
+        :returns: The blending mode of this node for the given Channel Type or for the mask.
+
+        See also:
+            :meth:`is_in_mask_stack`,
+            :meth:`has_blending`,
+            `Blending modes documentation`_
+        """
+    def set_blending_mode(self, blending_mode: BlendingMode, channel: ChannelType | None = None):
+        """
+        Set the blending mode for a Node.
+        If the node is not in a mask stack, a Channel Type must be provided.
+        If the node is in a mask stack, Channel Type must be None.
+
+        :param blending_mode: New blending mode to apply.
+        :param channel: Channel type to update or None for mask nodes.
+        :raises ValueError: If the node has blending information per Channel Type and no Channel
+                Type is provided, or if the node has blending information without Channel Type and
+                a Channel Type is provided.
+
+        See also:
+            :meth:`is_in_mask_stack`,
+            :meth:`has_blending`,
+            `Blending modes documentation`_
+        """
+    def get_opacity(self, channel: ChannelType | None = None) -> float:
+        """
+        Get the opacity for a Node.
+        If the node is not in a mask stack, a Channel Type must be provided.
+        If the node is in a mask stack, Channel Type must be None.
+
+        :param channel: Channel Type to query or None for mask nodes.
+        :raises ValueError: If the node has blending information per Channel Type and no Channel
+                Type is provided, or if the node has blending information without Channel Type and
+                a Channel Type is provided.
+        :returns: The opacity of this node for the given Channel Type or for the mask.
+
+        See also:
+            :meth:`is_in_mask_stack`
+            :meth:`has_blending`
+        """
+    def set_opacity(self, opacity: float, channel: ChannelType | None = None):
+        """
+        Set the opacity for a node.
+        If the node is not in a mask stack, a Channel Type must be provided.
+        If the node is in a mask stack, Channel Type must be None.
+
+        :param opacity: New opacity to apply, value between 0.0 and 1.0.
+        :param channel: Channel Type to update or None for mask nodes.
+        :raises ValueError: If the node has blending information per Channel Type and no Channel
+                Type is provided, or if the node has blending information without Channel Type and
+                a Channel Type is provided.
+
+        See also:
+            :meth:`is_in_mask_stack`
+            :meth:`has_blending`
+        """
+    def get_stack(self) -> Stack:
+        """
+        Get the stack that contains this node.
+
+        :returns: The stack that contains this node.
+        """
+    def get_parent(self) -> Node:
+        """
+        Get the parent of this node.
+
+        :returns: The parent of this node, or None if this node is a root layer.
+        """
+    def get_next_sibling(self) -> Node:
+        """
+        Get the next sibling of this node.
+
+        :returns: The next sibling of this node, or None if this node is the first sibling.
+        """
+    def get_previous_sibling(self) -> Node:
+        """
+        Get the previous sibling of this node.
+
+        :returns: The previous sibling of this node, or None if this node is the last sibling.
+        """
 
 class LayerNode(Node):
-    def content_effects(self) -> list[EffectNode]: ...
-    def mask_effects(self) -> list[EffectNode]: ...
-    def instances(self) -> list[LayerNode]: ...
-    def get_geometry_mask_type(self) -> GeometryMaskType: ...
-    def set_geometry_mask_type(self, geometry_mask_type: GeometryMaskType): ...
-    def get_geometry_mask_enabled_meshes(self) -> list[str]: ...
-    def set_geometry_mask_enabled_meshes(self, mesh_names: list[str]): ...
-    def get_geometry_mask_enabled_uv_tiles(self) -> list[UVTile]: ...
-    def set_geometry_mask_enabled_uv_tiles(self, uv_tiles: list[UVTile]): ...
-    def has_mask(self) -> bool: ...
-    def add_mask(self, background: MaskBackground): ...
-    def remove_mask(self) -> None: ...
-    def get_mask_background(self) -> MaskBackground: ...
-    def set_mask_background(self, background: MaskBackground): ...
-    def is_mask_enabled(self) -> bool: ...
-    def enable_mask(self, enabled: bool): ...
+    """
+    A Node that is part of the main hierarchy. Every Layer such as a paint or fill layer, as well as
+    groups, are organized into this hierarchy.
+    As such, you can query sub layers (in the case the LayerNode is a group), but also associate
+    content effects and mask effects (such as levels and filters and so on).
+
+    See also:
+        :func:`substance_painter.layerstack.get_node_by_uid`,
+        :ref:`layerstack_edition_insertion` section.
+    """
+    def content_effects(self) -> list[EffectNode]:
+        """
+        Query the content effects of this node, ordered like in the layer stack.
+
+        :returns: The content effects of this node.
+        """
+    def mask_effects(self) -> list[EffectNode]:
+        """
+        Query the mask effects of this node, ordered like in the layer stack.
+
+        :returns: The mask effects of this node.
+        """
+    def instances(self) -> list[LayerNode]:
+        """
+        Return the list of instances of this layer.
+        See the documentation on layer instancing if you are not familiar with the
+        concept: `Layer instancing documentation`_.
+
+        .. _Layer instancing documentation:
+            https://helpx.adobe.com/substance-3d-painter/interface/layer-stack/layer-instancing.html
+
+        :returns: The instances of this node.
+        """
+    def get_geometry_mask_type(self) -> GeometryMaskType:
+        """
+        Query the geometry mask type currently applied to this node.
+
+        :returns: The type of geometry mask for this layer node.
+
+        See also:
+            `Geometry mask documentation`_
+
+        .. _Geometry mask documentation:
+            https://helpx.adobe.com/substance-3d-painter/interface/layer-stack/geometry-mask.html
+
+        """
+    def set_geometry_mask_type(self, geometry_mask_type: GeometryMaskType):
+        """
+        Set the geometry mask type to apply to this node.
+        :class:`GeometryMaskType.UVTile <GeometryMaskType>` is only
+        supported when the corresponding Texture Set uses UV Tiles.
+
+        :param geometry_mask_type: The type of geometry mask for this layer node.
+        :raises ValueError: When GeometryMaskType.UVTile is requested and the project does not
+                support UV Tiles.
+
+        See also:
+            :meth:`substance_painter.textureset.TextureSet.has_uv_tiles`,
+            `Geometry mask documentation`_
+
+        """
+    def get_geometry_mask_enabled_meshes(self) -> list[str]:
+        """
+        Get the list of enabled meshes for the geometry mask. Meshes that are not in this list are
+        disabled.
+        To get the complete list of meshes, see
+        :meth:`substance_painter.textureset.TextureSet.all_mesh_names`.
+
+        :returns: The list of enabled meshes for the geometry mask.
+
+        See also:
+            `Geometry mask documentation`_
+        """
+    def set_geometry_mask_enabled_meshes(self, mesh_names: list[str]):
+        """
+        Set the list of enabled meshes for the geometry mask. Meshes that are not in this list will
+        be disabled. To get the complete list of meshes, see
+        :meth:`substance_painter.textureset.TextureSet.all_mesh_names`.
+
+        :param mesh_names: The list of meshes to enable for the geometry mask.
+        :raises ValueError: If a mesh name does not belongs to this texture set.
+
+        See also:
+            `Geometry mask documentation`_
+        """
+    def get_geometry_mask_enabled_uv_tiles(self) -> list[UVTile]:
+        """
+        Get the list of enabled UV Tiles for the geometry mask. UV Tiles that are not in this list
+        are disabled. To get the complete list of UV Tiles, see
+        :meth:`substance_painter.textureset.TextureSet.all_uv_tiles`.
+
+        :returns: The list of enabled UV Tiles for the geometry mask.
+
+        See also:
+            `Geometry mask documentation`_
+        """
+    def set_geometry_mask_enabled_uv_tiles(self, uv_tiles: list[UVTile]):
+        """
+        Set the list of enabled UV Tiles for the geometry mask. UV Tiles that are not in this list
+        will de disabled. To get the complete list of UV Tiles, see
+        :meth:`substance_painter.textureset.TextureSet.all_uv_tiles`.
+
+        :param uv_tiles: The list of UV Tiles to enable for the geometry mask.
+        :raises ValueError: If a UV Tile does not belong to this texture set.
+
+        See also:
+            `Geometry mask documentation`_
+        """
+    def has_mask(self) -> bool:
+        """
+        Check whether this node has a mask.
+
+        :returns: Whether this node has a mask.
+        """
+    def add_mask(self, background: MaskBackground):
+        """
+        Add a mask on this node with the specified background.
+
+        :raises ValueError: If a mask is already set on this node.
+                Use :meth:`has_mask` to check if the node has a mask.
+        """
+    def remove_mask(self) -> None:
+        """
+        Remove this node mask, including all its effects.
+
+        :raises ValueError: If no mask exists on this node.
+                Use :meth:`has_mask` to check if the node has a mask.
+        """
+    def get_mask_background(self) -> MaskBackground:
+        """
+        Query the type of mask used by this node.
+
+        :raises ValueError: If no mask exists on this node.
+                Use :meth:`has_mask` to check if the node has a mask.
+        :returns: The mask background applied to this node.
+        """
+    def set_mask_background(self, background: MaskBackground):
+        """
+        Set the mask background on this node.
+
+        :param background: The mask background to be applied on this node mask.
+        :raises ValueError: If no mask exists on this node.
+                Use :meth:`has_mask` to check if the node has a mask.
+        """
+    def is_mask_enabled(self) -> bool:
+        """
+        Query whether the mask is currently enabled.
+
+        :raises ValueError: If no mask exists on this node.
+                Use :meth:`has_mask` to check if the node has a mask.
+        :returns: Whether the mask is currently enabled.
+        """
+    def enable_mask(self, enabled: bool):
+        """
+        Set whether the mask is currently enabled.
+
+        :param enabled: Whether to enable the mask.
+        :raises ValueError: If no mask exists on this node.
+                Use :meth:`has_mask` to check if the node has a mask.
+        """
 
 class GroupLayerNode(LayerNode):
-    def sub_layers(self) -> list[LayerNode]: ...
-    def is_collapsed(self) -> bool: ...
-    def set_collapsed(self, collapsed: bool): ...
+    """
+    A node allowing manipulation of a Group layer of the Layer Stack.
+    """
+    def sub_layers(self) -> list[LayerNode]:
+        """
+        Query sub layers of this node. Only get the direct children, ordered like in the layer
+        stack.
 
-class PaintLayerNode(LayerNode): ...
+        :returns: The sub layers of this node.
+        """
+    def is_collapsed(self) -> bool:
+        """
+        Query if the group is in collapsed state.
+
+        :returns: Whether this group is collapsed.
+        """
+    def set_collapsed(self, collapsed: bool):
+        """
+        Set the collapsed state of the group.
+
+        :param collapsed: Whether to collapse the group.
+        """
+
+class PaintLayerNode(LayerNode):
+    """
+    A node allowing manipulation of a Paint layer.
+
+    Note:
+        Strokes are not accessible from the Python API.
+    """
 
 class InstanceLayerNode(LayerNode):
-    def instance_source(self) -> LayerNode: ...
+    """
+    A node allowing manipulation of an Instance layer.
 
-class FillLayerNode(FillParamsEditorMixin, SourceEditorMixin, LayerNode): ...
+    To retrieve the list of :class:`InstanceLayerNode` from the source layer,
+    see :meth:`LayerNode.instances`
+    """
+    def instance_source(self) -> LayerNode:
+        """
+        Return the source layer of this instance.
+
+        :returns: The source layer if this instance.
+        """
+
+class FillLayerNode(FillParamsEditorMixin, SourceEditorMixin, LayerNode):
+    """
+    A node allowing manipulation of a Fill layer.
+    """
 HierarchicalNode = LayerNode | GroupLayerNode | PaintLayerNode | InstanceLayerNode | FillLayerNode
 
 class GeneratorEffectNode(ActiveChannelsMixin, Node):
-    def get_source(self) -> SourceSubstance: ...
-    def set_source(self, res: substance_painter.resource.ResourceID) -> SourceSubstance: ...
-    def remove_source(self) -> None: ...
+    """
+    A node allowing manipulation of a Generator effect.
+    """
+    def get_source(self) -> SourceSubstance:
+        """
+        Get the source procedural of the generator, or None if no generator is set.
 
-class PaintEffectNode(Node): ...
-class FillEffectNode(FillParamsEditorMixin, SourceEditorMixin, Node): ...
+        :returns: The generator's source.
+        """
+    def set_source(self, res: substance_painter.resource.ResourceID) -> SourceSubstance:
+        """
+        Create and assign a source from the given resource and return the created source.
+        The resource must have a :class:`Usage.GENERATOR <substance_painter.resource.Usage>` usage.
+
+        :param res: The generator material to apply.
+        :raises ValueError: If `res` is not a valid resource or does not have
+                :class:`Usage.GENERATOR <substance_painter.resource.Usage>` usage.
+        :returns: The generator's source.
+        """
+    def remove_source(self) -> None:
+        """
+        Remove the currently used source.
+        """
+
+class PaintEffectNode(Node):
+    """
+    A node allowing manipulation of a Paint effect.
+
+    Note:
+        Strokes are not accessible from the Python API.
+    """
+class FillEffectNode(FillParamsEditorMixin, SourceEditorMixin, Node):
+    """
+    A node allowing manipulation of a Fill effect.
+    """
 
 class LevelsEffectNode(Node):
+    """
+    A node allowing manipulation of a Levels effect.
+
+    See also:
+        `Levels effect documentation`_
+
+    .. _Levels effect documentation:
+        https://helpx.adobe.com/substance-3d-painter/features/effects/levels.html
+    """
     @property
-    def affected_channel(self) -> ChannelType: ...
+    def affected_channel(self) -> ChannelType:
+        """
+        The channel affected by the current level effect.
+
+        :getter: Returns the affected channel.
+        :setter: Set the affected channel.
+        :type: ChannelType
+        """
     @affected_channel.setter
     def affected_channel(self, channel: ChannelType) -> None: ...
-    def get_parameters(self) -> LevelsParams: ...
-    def set_parameters(self, params: LevelsParams) -> None: ...
+    def get_parameters(self) -> LevelsParams:
+        """
+        Get the current parameters of this levels effect.
+
+        :returns: The current level parameters.
+        """
+    def set_parameters(self, params: LevelsParams) -> None:
+        """
+        Set new parameters for this levels effect.
+
+        :param params: The new parameters.
+        """
 
 @dataclasses.dataclass
 class CompareMaskEffectParams:
+    """
+    A compare mask effect parameters.
+
+    :param channel: The channel to compare between the source and the target to create a
+        mask from. Only used when some operands refers to Layers.
+    :param left_operand: The left operand of the comparison.
+    :param right_operand: The right operand of the comparison.
+    :param operation: The comparison operation to perform.
+    :param constant: Value to compare against when some operand is
+        :class:`CompareMaskEffectOperand.Constant <CompareMaskEffectOperand>`. Between 0.0 and 1.0.
+    :param tolerance: Tolerance value to use when `operation` is
+        :class:`CompareMaskEffectOperation.WithinTolerance <CompareMaskEffectOperand>`.
+        Between 0.0 and 1.0.
+    :param hardness: Controls the smoothness/hardness of the resulting mask comparison.
+        Between 0.0 and 1.0.
+    """
     channel: ChannelType
     left_operand: CompareMaskEffectOperand
     right_operand: CompareMaskEffectOperand
@@ -121,16 +690,67 @@ class CompareMaskEffectParams:
     hardness: float
 
 class CompareMaskEffectNode(Node):
-    def get_parameters(self) -> CompareMaskEffectParams: ...
-    def set_parameters(self, params: CompareMaskEffectParams) -> None: ...
+    """
+    A node allowing manipulation of a Compare Mask effect.
+
+    See also:
+        `Compare Mask effect documentation`_
+
+    .. _Compare Mask effect documentation:
+        https://helpx.adobe.com/substance-3d-painter/features/effects/compare-mask.html
+    """
+    def get_parameters(self) -> CompareMaskEffectParams:
+        """
+        Get the current parameters of this compare mask effect.
+
+        :returns: The current parameters of this compare mask effect.
+        """
+    def set_parameters(self, params: CompareMaskEffectParams) -> None:
+        """
+        Set new parameters of this compare mask effect.
+
+        :param params: The new parameters.
+        """
 
 class FilterEffectNode(ActiveChannelsMixin, Node):
-    def get_source(self) -> SourceSubstance: ...
-    def set_source(self, res: substance_painter.resource.ResourceID) -> SourceSubstance: ...
-    def remove_source(self) -> None: ...
+    """
+    A node allowing manipulation of a Filter effect.
+    """
+    def get_source(self) -> SourceSubstance:
+        """
+        Get the source procedural of the filter, or None if no filter is set.
+
+        :returns: The filter's source.
+        """
+    def set_source(self, res: substance_painter.resource.ResourceID) -> SourceSubstance:
+        """
+        Create and assign a source from the given resource and return the created source.
+        The resource must have a :class:`Usage.FILTER <substance_painter.resource.Usage>` usage.
+
+        :param res: The filter material to apply.
+        :raises ValueError: If `res` is not a valid resource or does not have
+                :class:`Usage.FILTER <substance_painter.resource.Usage>` usage.
+        :returns: The filter's source.
+        """
+    def remove_source(self) -> None:
+        """
+        Remove the currently used source.
+        """
 
 @dataclasses.dataclass
 class ColorSelectionEffectParams:
+    """
+    A color selection effect parameters.
+
+    :param id_mask: Which color map to use.
+        Typically the ID Mask baked map. Must have
+        :class:`Usage.TEXTURE <substance_painter.resource.Usage>` and be part of the project.
+    :param output_value: Output value when selection matches. Between 0.0 and 1.0.
+    :param hardness: Hardness of the selection. Between 0.0 and 1.0.
+    :param tolerance: Tolerance of the selection. Between 0.0 and 1.0.
+    :param background_color: Output value when selection does not match.
+    :param colors: List of colors to match in the id_mask.
+    """
     id_mask: substance_painter.resource.ResourceID | None
     output_value: float
     hardness: float
@@ -139,22 +759,108 @@ class ColorSelectionEffectParams:
     colors: list[Color]
 
 class ColorSelectionEffectNode(Node):
-    def get_parameters(self) -> ColorSelectionEffectParams: ...
-    def set_parameters(self, params: ColorSelectionEffectParams) -> None: ...
+    """
+    A node allowing manipulation of a Color Selection effect.
+    """
+    def get_parameters(self) -> ColorSelectionEffectParams:
+        """
+        Get the current parameters of this color selection effect.
 
-class AnchorPointEffectNode(Node): ...
+        :returns: The current parameters of this color selection effect.
+        """
+    def set_parameters(self, params: ColorSelectionEffectParams) -> None:
+        """
+        Set new parameters of this compare mask effect.
+
+        :param params: The new parameters.
+        :raises ResourceNotFoundError: If the resource ``params.id_mask`` is not found or is not of
+                :class:`Type.IMAGE <substance_painter.resource.Type>`.
+        """
+
+class AnchorPointEffectNode(Node):
+    """
+    A node allowing manipulation of an Anchor Point effect.
+    """
 EffectNode = GeneratorEffectNode | PaintEffectNode | FillEffectNode | LevelsEffectNode | CompareMaskEffectNode | FilterEffectNode | ColorSelectionEffectNode | AnchorPointEffectNode
 
-def get_root_layer_nodes(stack: Stack) -> list[HierarchicalNode]: ...
-def get_node_by_uid(node_id: int) -> list[HierarchicalNode | EffectNode]: ...
-def get_selected_nodes(stack: Stack) -> list[HierarchicalNode | EffectNode]: ...
-def set_selected_nodes(nodes: list[EffectNode] | list[LayerNode]): ...
-def get_selection_type(layer: LayerNode) -> SelectionType: ...
-def set_selection_type(layer: LayerNode, layer_selection_type: SelectionType): ...
-def delete_node(node: Node): ...
+def get_root_layer_nodes(stack: Stack) -> list[HierarchicalNode]:
+    """
+    Get the root layers of a stack, ordered like in the layer stack.
+
+    :param stack: Stack to query.
+    :raises ValueError: If `stack` is invalid.
+    :returns: The root layers of the stack.
+    """
+def get_node_by_uid(node_id: int) -> list[HierarchicalNode | EffectNode]:
+    """
+    Get a node by its internal identifier.
+
+    :param node_id: The node uid.
+    :raises ValueError: If the given uid doesn't correspond to a valid node.
+    :returns: The node with the given uid.
+    """
+def get_selected_nodes(stack: Stack) -> list[HierarchicalNode | EffectNode]:
+    """
+    Get the selected nodes of a Stack, ordered like in the layer stack.
+
+    :param stack: Stack to query.
+    :returns: The selected nodes of the stack.
+    """
+def set_selected_nodes(nodes: list[EffectNode] | list[LayerNode]):
+    """
+    Select the given nodes in the layer stack UI.
+
+    :pararm nodes: Nodes to select.
+    :raises ValueError: If the nodes doesn't belong to the currently selected texture set.
+    :raises RuntimeError: If called from a :class:`ScopedModification` section
+    """
+def get_selection_type(layer: LayerNode) -> SelectionType:
+    """
+    Return which part of a layer is selected (content, mask, etc...).
+
+    :param layer: Layer to query.
+    :raises ValueError: If the layer doesn't belong to the currently selected texture set.
+    :returns: The part of the layer that is selected.
+    """
+def set_selection_type(layer: LayerNode, layer_selection_type: SelectionType):
+    """
+    Select which part of the layer you want to select.
+
+    :param layer: Layer to select.
+    :param layer_selection_type: Part of the layer you want to select (content, mask, etc...).
+    :raises ValueError: If the layer doesn't belong to the currently selected texture set.
+    :raises RuntimeError: If called from a :class:`ScopedModification` section
+    """
+def delete_node(node: Node):
+    """
+    Delete the given node.
+
+    :param node: Node to delete.
+    """
 
 @dataclasses.dataclass
 class UVTransformationParams:
+    """
+    UV projection transformation parameters.
+
+    :param scale_mode: How `scale` should be interpreted.
+        For a :class:`ProjectionMode.Spherical <ProjectionMode>` projection,
+        only :class:`ScaleMode.Factors <ScaleMode>` is supported.
+        Using :class:`ScaleMode.MaterialPhysicalSize <ScaleMode>` is only possible when
+        applied to a resource with physical size information.
+    :param scale: The u/v stretch applied to the texture.
+        When `scale_mode` is :class:`ScaleMode.Factors <ScaleMode>`,
+        use plain factor for stretching.
+        When `scale_mode` is :class:`ScaleMode.MaterialPhysicalSize <ScaleMode>`, scale must be None
+        and the value will be forced to the actual material physical size.
+        When `scale_mode` is :class:`ScaleMode.CustomPhysicalSize <ScaleMode>`, then scale is
+        expressed in centimeters and overrides the size defined by the material
+        (useful when material has no physical size information).
+    :param rotation: Rotation applied to the texture.
+    :param offset: Offset applied to the texture.
+        The offset is unavailable for a :class:`ProjectionMode.Triplanar <ProjectionMode>`
+        projection.
+    """
     scale_mode: ScaleMode = ...
     scale: list[float] = ...
     rotation: float = ...
@@ -162,23 +868,75 @@ class UVTransformationParams:
 
 @dataclasses.dataclass
 class Projection3DParams:
+    """
+    3D projection transformation parameters.
+
+    :param offset: 3D offset.
+    :param rotation: 3D rotation.
+    :param scale: 3D scale.
+        Z scaling is unavalaible when projection mode is
+        :class:`ProjectionMode.Planar <ProjectionMode>` and depth culling is disabled.
+    """
     offset: list[float] = ...
     rotation: list[float] = ...
     scale: list[float] = ...
 
 @dataclasses.dataclass
 class ProjectionCullingParams:
+    """
+    Projection culling parameters.
+    Either a depth culling or a backface culling.
+
+    :param enabled: Whether the culling is enabled or not.
+    :param hardness: Hardness of the culling, between 0 and 1.
+    """
     enabled: bool = ...
     hardness: float = ...
 
 @dataclasses.dataclass
 class UVProjectionParams:
+    """
+    Parameters that control the fill behaviour when the projection mode is
+    :class:`ProjectionMode.UV <ProjectionMode>`.
+    For a complete description of the parameters, see
+    `UV Projection documentation`_.
+
+    .. _UV Projection documentation:
+        https://helpx.adobe.com/substance-3d-painter/painting/fill-projections/uv-projection.html
+
+    :param filtering_mode: How to filter the image.
+    :param uv_wrapping: UV Wrapping behaviour.
+    :param uv_transformation: UV transformation.
+
+    See also:
+        :meth:`FillLayerNode.get_projection_mode`
+        :meth:`FillLayerNode.get_projection_parameters`
+    """
     filtering_mode: FilteringMode = ...
     uv_wrapping_mode: UVWrapMode = ...
     uv_transformation: UVTransformationParams = dataclasses.field(default_factory=UVTransformationParams)
 
 @dataclasses.dataclass
 class TriplanarProjectionParams:
+    """
+    Parameters that control the fill behaviour when the projection mode is
+    :class:`ProjectionMode.Triplanar <ProjectionMode>`.
+    For a complete description of the parameters, see
+    `Triplanar Projection documentation`_.
+
+    .. _Triplanar Projection documentation:
+        https://helpx.adobe.com/substance-3d-painter/painting/fill-projections/tri-planar-projection.html
+
+    :param filtering_mode: How to filter the image.
+    :param shape_crop_mode: How the fill is cropped.
+    :param hardness: How hard is the transition between planes of the projection.
+    :param uv_transformation: UV transformation.
+    :param projection_3d: 3D projection.
+
+    See also:
+        :meth:`FillLayerNode.get_projection_mode`
+        :meth:`FillLayerNode.get_projection_parameters`
+    """
     filtering_mode: FilteringMode = ...
     shape_crop_mode: ShapeCropMode = ...
     hardness: float = ...
@@ -187,6 +945,29 @@ class TriplanarProjectionParams:
 
 @dataclasses.dataclass
 class PlanarProjectionParams:
+    """
+    Parameters that control the fill behaviour when the projection mode is
+    :class:`ProjectionMode.Planar <ProjectionMode>`.
+    For a complete description of the parameters, see
+    `Planar Projection documentation`_.
+
+    .. _Planar Projection documentation:
+        https://helpx.adobe.com/substance-3d-painter/painting/fill-projections/planar-projection.html
+
+    :param filtering_mode: How to filter the image.
+    :param uv_wrapping_mode: UV Wrapping behaviour.
+    :param shape_crop_mode: How the fill is cropped.
+    :param depth_culling: Depth culling settings.
+    :param backface_culling: Backface culling settings.
+    :param backface_culling_angle: Minimum angle which determines when faces that are looking
+        away should be ignored, between 45 and 135.
+    :param uv_transformation: UV transformation.
+    :param projection_3d: 3D projection.
+
+    See also:
+        :meth:`FillLayerNode.get_projection_mode`
+        :meth:`FillLayerNode.get_projection_parameters`
+    """
     filtering_mode: FilteringMode = ...
     uv_wrapping_mode: UVWrapMode = ...
     shape_crop_mode: ShapeCropMode = ...
@@ -198,6 +979,27 @@ class PlanarProjectionParams:
 
 @dataclasses.dataclass
 class WarpProjectionParams:
+    """
+    Parameters that control the fill behaviour when the projection mode is
+    :class:`ProjectionMode.Warp <ProjectionMode>`.
+    For a complete description of the parameters, see
+    `Warp Projection documentation`_.
+
+    .. _Warp Projection documentation:
+        https://helpx.adobe.com/substance-3d-painter/painting/fill-projections/warp-projection.html
+
+    :param filtering_mode: How to filter the image.
+    :param uv_wrapping_mode: UV Wrapping behaviour.
+    :param shape_crop_mode: How the fill is cropped.
+    :param projection_depth: How far the projection goes along its Z axis.
+    :param depth_culling: Depth culling parameters.
+    :param uv_transformation: UV transformation.
+    :param projection_3d: 3D projection.
+
+    See also:
+        :meth:`FillLayerNode.get_projection_mode`
+        :meth:`FillLayerNode.get_projection_parameters`
+    """
     filtering_mode: FilteringMode = ...
     uv_wrapping_mode: UVWrapMode = ...
     shape_crop_mode: ShapeCropMode = ...
@@ -208,6 +1010,26 @@ class WarpProjectionParams:
 
 @dataclasses.dataclass
 class SphericalProjectionParams:
+    """
+    Parameters that control the fill behaviour when the projection mode is
+    :class:`ProjectionMode.Spherical <ProjectionMode>`.
+    For a complete description of the parameters, see
+    `Spherical Projection documentation`_.
+
+    .. _Spherical Projection documentation:
+        https://helpx.adobe.com/substance-3d-painter/painting/fill-projections/spherical-projection.html
+
+    :param filtering_mode: How to filter the image.
+    :param uv_wrapping_mode: UV Wrapping behaviour.
+    :param shape_crop_mode: How the fill is cropped.
+    :param uv_transformation: UV transformation.
+        Spherical projection do not support UV transformation physical size options.
+    :param projection_3d: 3D projection.
+
+    See also:
+        :meth:`FillLayerNode.get_projection_mode`
+        :meth:`FillLayerNode.get_projection_parameters`
+    """
     filtering_mode: FilteringMode = ...
     uv_wrapping_mode: UVWrapMode = ...
     shape_crop_mode: ShapeCropMode = ...
@@ -216,6 +1038,27 @@ class SphericalProjectionParams:
 
 @dataclasses.dataclass
 class CylindricalProjectionParams:
+    """
+    Parameters that control the fill behaviour when the projection mode is
+    :class:`ProjectionMode.Cylindrical <ProjectionMode>`.
+    For a complete description of the parameters, see
+    `Cylindrical Projection documentation`_.
+
+    .. _Cylindrical Projection documentation:
+        https://helpx.adobe.com/substance-3d-painter/painting/fill-projections/cylindrical-projection.html
+
+    :param filtering_mode: How to filter the image.
+    :param uv_wrapping_mode: UV Wrapping behaviour.
+    :param shape_crop_mode: How the fill is cropped.
+    :param angle: Size of the projection on the perimeter of the cylinder.
+    :param backface_culling: Backface culling parameters.
+    :param uv_transformation: UV transformation.
+    :param projection_3d: 3D projection.
+
+    See also:
+        :meth:`FillLayerNode.get_projection_mode`
+        :meth:`FillLayerNode.get_projection_parameters`
+    """
     filtering_mode: FilteringMode = ...
     uv_wrapping_mode: UVWrapMode = ...
     shape_crop_mode: ShapeCropMode = ...
@@ -226,34 +1069,326 @@ class CylindricalProjectionParams:
 
 @dataclasses.dataclass
 class UVSetToUVSetProjectionParams:
+    """
+    Parameters that control the fill behaviour when the projection mode is
+    :class:`ProjectionMode.UVSetToUVSet <ProjectionMode>`.
+    For a complete description of the parameters, see
+    `UVSetToUVSet Projection documentation`_.
+
+    .. _UVSetToUVSet Projection documentation:
+        https://helpx.adobe.com/substance-3d-painter/painting/fill-projections/uv-set-to-uv-set-projection.html
+
+    :param source_uv_set: Mesh UV set index used as projection source (0: no effect).
+    :param filtering_mode: How to filter the image.
+    :param uv_wrapping: UV Wrapping behaviour.
+    :param uv_transformation: UV transformation.
+
+    See also:
+        :meth:`FillLayerNode.get_projection_mode`
+        :meth:`FillLayerNode.get_projection_parameters`
+    """
     source_uv_set: int = ...
     filtering_mode: FilteringMode = ...
     uv_wrapping_mode: UVWrapMode = ...
     uv_transformation: UVTransformationParams = dataclasses.field(default_factory=UVTransformationParams)
 ProjectionParams = UVProjectionParams | TriplanarProjectionParams | PlanarProjectionParams | WarpProjectionParams | SphericalProjectionParams | CylindricalProjectionParams | UVSetToUVSetProjectionParams
 
+@dataclasses.dataclass
+class MirrorSymmetryParams:
+    """
+    Parameters that control the mirror symmetry behaviour.
+
+    :param axis: Axis along which to mirror.
+    :param flip_u: Whether to flip UVs along the U axis.
+    :param flip_v: Whether to flip UVs along the V axis.
+    :param axis_position: Position of the mirror plane along each axis, clamped between [-10, -10,
+        -10] and [10, 10, 10].
+
+    See also:
+        :meth:`FillLayerNode.get_symmetry_mode`
+        :meth:`FillLayerNode.get_symmetry_parameters`
+    """
+    axis: SymmetryAxis = ...
+    flip_u: bool = ...
+    flip_v: bool = ...
+    axis_position: list[float] = ...
+
+@dataclasses.dataclass
+class RadialSymmetryParams:
+    """
+    Parameters that control the radial symmetry behaviour.
+
+    When setting symmetry, some parameters will get clamped:
+
+    :param axis: Axis along which to mirror.
+    :param flip_u: Whether to flip UVs along the U axis.
+    :param flip_v: Whether to flip UVs along the V axis.
+    :param axis_position: Position of the mirror plane along each axis, clamped between [-10, -10,
+        -10] and [10, 10, 10].
+    :param count: Number of copies, clamped between 2 and 16.
+    :param angle_span: Angle span of the copies, in degrees, clamped between -360 and 360.
+
+    See also:
+        :meth:`FillLayerNode.get_symmetry_mode`
+        :meth:`FillLayerNode.get_symmetry_parameters`
+    """
+    axis: SymmetryAxis = ...
+    flip_u: bool = ...
+    flip_v: bool = ...
+    axis_position: list[float] = ...
+    count: int = ...
+    angle_span: float = ...
+SymmetryParams = MirrorSymmetryParams | RadialSymmetryParams
+
 @dataclasses.dataclass(frozen=True)
 class InsertPosition:
+    '''
+    :class:`InsertPosition` is the object used by all the insert methods to express
+    where you want the insertion to happen in the layer stack hierarchy.
+
+    Create instances using the appropriate static methods depending on what
+    you want to do. See the following examples.
+
+    Example:
+        ::
+
+            import substance_painter as sp
+
+            # Insert at the top of the given textureset layer stack
+            insert_position = sp.layerstack.InsertPosition.from_textureset_stack(
+                sp.textureset.get_active_stack())
+            new_layer = sp.layerstack.insert_fill(insert_position)
+            new_layer.set_name("First layer")
+
+            # Insert a layer above new_layer
+            insert_position = sp.layerstack.InsertPosition.above_node(new_layer)
+            sp.layerstack.insert_fill(insert_position)
+
+            # Insert an effect in the content stack of new_layer
+            insert_position = sp.layerstack.InsertPosition.inside_node(
+                new_layer, sp.layerstack.NodeStack.Content)
+            new_effect = sp.layerstack.insert_fill(insert_position)
+            new_effect.set_name("First effect")
+
+            # Insert an effect below new_effect
+            insert_position = sp.layerstack.InsertPosition.below_node(new_effect)
+            sp.layerstack.insert_fill(insert_position)
+    '''
     node_id: int
     node_stack: int | None
     @staticmethod
-    def from_textureset_stack(stack: substance_painter.textureset.Stack) -> InsertPosition: ...
-    @staticmethod
-    def above_node(node: Node) -> InsertPosition: ...
-    @staticmethod
-    def below_node(node: Node) -> InsertPosition: ...
-    @staticmethod
-    def inside_node(node: Node, node_stack: NodeStack) -> InsertPosition: ...
+    def from_textureset_stack(stack: substance_painter.textureset.Stack) -> InsertPosition:
+        """
+        Generate an :class:`InsertPosition` on the top of a stack.
 
-def insert_fill(position: InsertPosition) -> FillLayerNode | FillEffectNode: ...
-def insert_paint(position: InsertPosition) -> PaintLayerNode | PaintEffectNode: ...
-def insert_group(position: InsertPosition) -> GroupLayerNode: ...
-def instantiate(position: InsertPosition, layer: LayerNode) -> InstanceLayerNode: ...
-def insert_levels_effect(position: InsertPosition) -> LevelsEffectNode: ...
-def insert_compare_mask_effect(position: InsertPosition) -> CompareMaskEffectNode: ...
-def insert_filter_effect(position: InsertPosition, filter_substance: substance_painter.resource.ResourceID | None = None) -> FilterEffectNode: ...
-def insert_generator_effect(position: InsertPosition, generator_substance: substance_painter.resource.ResourceID | None = None) -> GeneratorEffectNode: ...
-def insert_anchor_point_effect(position: InsertPosition, name: str) -> AnchorPointEffectNode: ...
-def insert_color_selection_effect(position: InsertPosition) -> ColorSelectionEffectNode: ...
-def insert_smart_material(position: InsertPosition, smart_material: substance_painter.resource.ResourceID) -> GroupLayerNode: ...
-def insert_smart_mask(position: InsertPosition, smart_mask: substance_painter.resource.ResourceID) -> list[EffectNode]: ...
+        Only a :class:`LayerNode` can be inserted at the top of the stack.
+        For more details, see :ref:`insertion_rules_layer`.
+
+        :pararm stack: Stack in which you wish to insert.
+        """
+    @staticmethod
+    def above_node(node: Node) -> InsertPosition:
+        """
+        Generate an :class:`InsertPosition` to insert above the given node.
+
+        Only a :class:`LayerNode` can be inserted above a :class:`LayerNode`.
+        Only an :class:`EffectNode` can be inserted above an :class:`EffectNode`.
+        For more details, see :ref:`insertion_rules_layer` and :ref:`insertion_rules_effect`.
+
+        :param node: the node.
+        """
+    @staticmethod
+    def below_node(node: Node) -> InsertPosition:
+        """
+        Generate an :class:`InsertPosition` to insert below the given node.
+
+        Only a :class:`LayerNode` can be inserted above a :class:`LayerNode`.
+        Only an :class:`EffectNode` can be inserted above an :class:`EffectNode`.
+        For more details, see :ref:`insertion_rules_layer` and :ref:`insertion_rules_effect`.
+
+        :param node: the node.
+        """
+    @staticmethod
+    def inside_node(node: Node, node_stack: NodeStack) -> InsertPosition:
+        """
+        Generate an :class:`InsertPosition` to insert inside the given stack of a node.
+
+        Only a :class:`LayerNode` can be inserted inside a :class:`GroupLayerNode` if `node_stack`
+        is :class:`NodeStack.Substack <NodeStack>`.
+        Only an :class:`EffectNode` can be inserted inside a :class:`LayerNode` if `node_stack`
+        is :class:`NodeStack.Content <NodeStack>` or :class:`NodeStack.Mask <NodeStack>`.
+        For more details, see :ref:`insertion_rules_layer` and :ref:`insertion_rules_effect`.
+
+        :param node: the node.
+        :param node_stack: indicate in which layer's stack you want
+                to insert (Only valid for nodes which are layers).
+        """
+
+def insert_fill(position: InsertPosition) -> FillLayerNode | FillEffectNode:
+    """
+    Insert a Fill effect or layer (depending on the insert position).
+
+    :param position: Insert position.
+    :raises ValueError: If insertion failed due to an invalid `position`.
+            See :class:`InsertPosition`.
+    :returns: The inserted node.
+    """
+def insert_paint(position: InsertPosition) -> PaintLayerNode | PaintEffectNode:
+    """
+    Insert a Paint effect or layer (depending on the insert position).
+
+    :param position: Insert position.
+    :raises ValueError: If insertion failed due to an invalid `position`.
+            See :class:`InsertPosition`.
+    :returns: The inserted node.
+    """
+def insert_group(position: InsertPosition) -> GroupLayerNode:
+    """
+    Insert a group layer.
+
+    :param position: The insert position must be either inside
+            a :class:`GroupLayerNode` with :class:`NodeStack.Substack <NodeStack>`
+            or above/below a :class:`LayerNode`.
+    :raises ValueError: If insertion failed due to an invalid `position`.
+            See :class:`InsertPosition`.
+    :returns: The inserted node.
+    """
+def instantiate(position: InsertPosition, layer: LayerNode) -> InstanceLayerNode:
+    """
+    Instantiate the given layer.
+    See the documentation on layer instancing if you are not familiar with the
+    concept: `Layer instancing documentation`_.
+
+    .. _Layer instancing documentation:
+        https://helpx.adobe.com/substance-3d-painter/interface/layer-stack/layer-instancing.html
+
+    :param position: Insert position.
+    :param layer: Layer to instantiate.
+    :raises ValueError: If insertion failed due to an invalid `position`.
+            See :class:`InsertPosition`.
+    :returns: The inserted node.
+    """
+def insert_levels_effect(position: InsertPosition) -> LevelsEffectNode:
+    """
+    Insert a levels effect with default parameters.
+
+    :param position: The insert position must be either inside
+            a :class:`LayerNode` with :class:`NodeStack.Content <NodeStack>`
+            or :class:`NodeStack.Mask <NodeStack>`
+            or above/below an :class:`EffectNode`.
+    :raises ValueError: If insertion failed due to an invalid `position`.
+            See :class:`InsertPosition`.
+    :returns: The inserted node.
+    """
+def insert_compare_mask_effect(position: InsertPosition) -> CompareMaskEffectNode:
+    """
+    Insert a compare mask effect with default parameters.
+
+    :param position: The insert position must be either inside
+            a :class:`LayerNode` with :class:`NodeStack.Mask <NodeStack>`
+            or above/below an :class:`EffectNode` in the mask stack.
+    :raises ValueError: If insertion failed due to an invalid `position`.
+            See :class:`InsertPosition`.
+    :returns: The inserted node.
+    """
+def insert_filter_effect(position: InsertPosition, filter_substance: substance_painter.resource.ResourceID | None = None) -> FilterEffectNode:
+    """
+    Insert a filter effect, either empty or with the given filter resource.
+
+    :param position: The insert position must be either inside
+            a :class:`LayerNode` with :class:`NodeStack.Content <NodeStack>`
+            or :class:`NodeStack.Mask <NodeStack>`
+            or above/below an :class:`EffectNode`.
+    :param filter_substance: Resource to use as filter. The resource must have a
+            :class:`Usage.FILTER <substance_painter.resource.Usage>` usage.
+    :raises ValueError: If insertion failed due to an invalid `position`.
+            See :class:`InsertPosition`.
+    :raises ValueError: If `filter_substance` is not a valid resource or
+            does not have :class:`Usage.FILTER <substance_painter.resource.Usage>` usage.
+    :returns: The inserted node.
+    """
+def insert_generator_effect(position: InsertPosition, generator_substance: substance_painter.resource.ResourceID | None = None) -> GeneratorEffectNode:
+    """
+    Insert a Generator effect, either empty or with the given filter resource.
+
+    :param position: The insert position must be either inside
+            a :class:`LayerNode` with :class:`NodeStack.Content <NodeStack>` or
+            :class:`NodeStack.Mask <NodeStack>` or above/below an :class:`EffectNode`.
+    :param generator_substance: Resource to use as generator. The resource must have a
+            :class:`Usage.GENERATOR <substance_painter.resource.Usage>` usage.
+    :raises ValueError: If insertion failed due to an invalid `position`.
+            See :class:`InsertPosition`.
+    :raises ValueError: If `generator_substance` is not a valid resource or
+            does not have :class:`Usage.GENERATOR <substance_painter.resource.Usage>` usage.
+    :returns: The inserted node.
+    """
+def insert_anchor_point_effect(position: InsertPosition, name: str) -> AnchorPointEffectNode:
+    """
+    Insert an anchor point effect.
+
+    :param position: The insert position must be either inside
+            a :class:`LayerNode` with :class:`NodeStack.Content <NodeStack>`
+            or :class:`NodeStack.Mask <NodeStack>`
+            or above/below an :class:`EffectNode`.
+    :param name: Name of the anchor point.
+    :raises ValueError: If insertion failed due to an invalid `position`.
+            See :class:`InsertPosition`.
+    :returns: The new anchor point.
+    """
+def insert_color_selection_effect(position: InsertPosition) -> ColorSelectionEffectNode:
+    """
+    Insert a color selection effect.
+
+    :param position: The insert position must be either inside
+            a :class:`LayerNode` with :class:`NodeStack.Mask <NodeStack>`
+            or above/below an :class:`EffectNode` in the mask stack.
+    :raises ValueError: If insertion failed due to an invalid `position`.
+            See :class:`InsertPosition`.
+    :returns: The inserted node.
+    """
+def insert_smart_material(position: InsertPosition, smart_material: substance_painter.resource.ResourceID) -> GroupLayerNode:
+    """
+    Insert a smart material at the given position.
+
+    :param position: The insert position must be either inside
+            a :class:`GroupLayerNode` with :class:`NodeStack.Substack <NodeStack>`
+            or above/below a :class:`LayerNode`.
+    :param smart_material: The smart material to instantiate. The resource must have a
+            :class:`Usage.SMART_MATERIAL <substance_painter.resource.Usage>` usage.
+    :raises ValueError: If insertion failed due to an invalid `position`.
+            See :class:`InsertPosition`.
+    :raises ValueError: If `smart_material` is not a valid resource or does not have
+            :class:`Usage.SMART_MATERIAL <substance_painter.resource.Usage>` usage.
+    :returns: The inserted node.
+    """
+def create_smart_material(group: GroupLayerNode, name: str) -> substance_painter.resource.Resource:
+    """
+    Create a smart material with name ``name`` from the given ``group``.
+
+    :param group: The root folder of the smart material.
+    :param name: The name of the smart material.
+    :returns: The created smart material as a resource.
+    """
+def insert_smart_mask(position: InsertPosition, smart_mask: substance_painter.resource.ResourceID) -> list[EffectNode]:
+    """
+    Insert a smart mask in a mask stack.
+
+    :param position: The insert position must be either inside
+            a :class:`LayerNode` with :class:`NodeStack.Mask <NodeStack>`
+            or above/below an :class:`EffectNode` in the mask stack.
+    :param smart_mask: The smart mask to instantiate. The resource must have a
+            :class:`Usage.SMART_MASK <substance_painter.resource.Usage>` usage.
+    :raises ValueError: If insertion failed due to an invalid `position`.
+            See :class:`InsertPosition`.
+    :raises ValueError: If `smart_mask` is not a valid resource or does not have
+            :class:`Usage.SMART_MASK <substance_painter.resource.Usage>` usage.
+    :returns: The inserted nodes.
+    """
+def create_smart_mask(layer: LayerNode, name: str) -> substance_painter.resource.Resource:
+    """
+    Create a smart mask with name ``name`` from the mask stack of the given ``layer``.
+
+    :param layer: The parent layer of the mask stack to create.
+    :param name: The name of the smart mask.
+    :returns: The created smart mask as a resource.
+    """

--- a/substance_painter/stubs/substance_painter-stubs/levels.pyi
+++ b/substance_painter/stubs/substance_painter-stubs/levels.pyi
@@ -2,6 +2,16 @@ import dataclasses
 
 @dataclasses.dataclass
 class LevelsParamsRGB:
+    """
+    A levels parameters, when in RGB color mode.
+
+    :param input_min: The minimum input threshold.
+    :param input_max: The maximum input threshold.
+    :param gamma: Gamma.
+    :param output_min: The minimum output threshold.
+    :param output_max: The maximum output threshold.
+    :param clamp: Wether the values should be clamped or not.
+    """
     input_min: tuple[float, float, float] = ...
     input_max: tuple[float, float, float] = ...
     gamma: tuple[float, float, float] = ...
@@ -11,6 +21,16 @@ class LevelsParamsRGB:
 
 @dataclasses.dataclass
 class LevelsParamsMono:
+    """
+    A levels parameters, when in Luminance or only one color mode.
+
+    :param input_min: The minimum input threshold.
+    :param input_max: The maximum input threshold.
+    :param gamma: Gamma.
+    :param output_min: The minimum output threshold.
+    :param output_max: The maximum output threshold.
+    :param clamp: Wether the values should be clamped or not.
+    """
     input_min: float = ...
     input_max: float = ...
     gamma: float = ...

--- a/substance_painter/stubs/substance_painter-stubs/logging.pyi
+++ b/substance_painter/stubs/substance_painter-stubs/logging.pyi
@@ -8,7 +8,33 @@ DBG_INFO: Incomplete
 DBG_WARNING: Incomplete
 DBG_ERROR: Incomplete
 
-def log(severity, channel: str, message: str): ...
-def info(message: str): ...
-def warning(message: str): ...
-def error(message: str): ...
+def log(severity, channel: str, message: str):
+    """Logs a message with level `severity` on the Substance 3D Painter logger.
+
+    Args:
+      severity: the severity level, can be ``INFO``, ``WARNING`` or ``ERROR`` for
+          messages relevant to the end user, or ``DBG_INFO``, ``DBG_WARNING`` or
+          ``DBG_ERROR`` for messages relevant to the developer.
+      channel (str): the channel to log into.  This can be any name allowing to
+                     identify the origin of the message, for example the name of
+                     your plugin.
+      message (str): the message to log.
+    """
+def info(message: str):
+    """Logs a message with level ``INFO`` on the Substance 3D Painter logger.
+
+    Args:
+        message (str): The message to log.
+    """
+def warning(message: str):
+    """Logs a message with level ``WARNING`` on the Substance 3D Painter logger.
+
+    Args:
+        message (str): The warning message to log.
+    """
+def error(message: str):
+    """Logs a message with level ``ERROR`` on the Substance 3D Painter logger.
+
+    Args:
+        message (str): The error message to log.
+    """

--- a/substance_painter/stubs/substance_painter-stubs/project.pyi
+++ b/substance_painter/stubs/substance_painter-stubs/project.pyi
@@ -13,6 +13,32 @@ from _substance_painter.project import ProjectWorkflow as ProjectWorkflow
 
 @dataclasses.dataclass
 class UsdSettings:
+    '''
+    Specific settings for USD files.
+
+    This corresponds to the options that are available in the File type-specific settings section
+    in the "New project" and "Project configuration" dialogs.
+
+    :param scope_name: Scope name of the primitive to load in the hierarchy. The path must be
+        absolute. Expected syntax: ``"/my/path/name"``.
+        If not specified, default scope name is the root ``"/"``. Only available for USD files.
+    :param variants: Define which variant to use for each primitive path. Values are expected in
+        JSON format.
+        ::
+
+            [
+                {
+                    "primPath": "/my/path/name",
+                    "selectionName: "variantName",
+                    "setName": "variantSetName"
+                }
+            ]
+
+        Only available for USD files.
+    :param subdivision_level: The subdivision level is applied only on geometry built with
+        subdivision. Only available for USD files.
+    :param frame: The frame to import. Only available for animated USD files.
+    '''
     scope_name: str = ...
     variants: dict = ...
     subdivision_level: int = ...
@@ -20,10 +46,47 @@ class UsdSettings:
 
 @dataclasses.dataclass
 class GltfSettings:
+    '''
+    Specific settings for GLTF files.
+
+    This corresponds to the options that are available in the File type-specific settings section
+    in the "New project" dialog.
+
+    :param invert_normal_maps: Invert normal maps at import. Only available for GLTF files.
+    '''
     invert_normal_maps: bool = ...
 
 @dataclasses.dataclass
 class Settings:
+    '''
+    Project configuration options. All options can be set to ``None`` to use the default values.
+
+    This corresponds to the options that are available in the "New project" dialog.
+
+    See also:
+        :class:`NormalMapFormat`,
+        :class:`TangentSpace`,
+        :class:`ProjectWorkflow`,
+        :func:`create`,
+        `Project configuration documentation`_.
+
+    .. _Project configuration documentation:
+        https://www.adobe.com/go/painter-project-configuration
+
+    :param default_save_path: The default save path.
+    :param normal_map_format: Normal map system coordinates. OpenGL or DirectX format.
+    :param tangent_space_mode: Per vertex or per fragment tangent space.
+    :param project_workflow: Project workflow, selected at project creation time.
+    :param export_path: Use this path as the default map export path.
+    :param default_texture_resolution: Default resolution for all the Texture Sets.
+    :param import_cameras: Import cameras from the mesh file.
+    :param mesh_unit_scale: Use custom unit scale for input mesh. Painter unit is centimeters.
+        If set to 0 or None, use mesh file internal unit scale.
+        This setting is necessary for .obj meshes that use units other than centimeters.
+    :param mesh_settings: Specific mesh settings.
+    :param usd_settings: Deprecated, use mesh_settings instead.
+    :type usd_settings: UsdSettings
+    '''
     default_save_path: str = ...
     normal_map_format: NormalMapFormat = ...
     tangent_space_mode: TangentSpace = ...
@@ -34,58 +97,511 @@ class Settings:
     mesh_unit_scale: float = ...
     mesh_settings: UsdSettings | GltfSettings = ...
     @property
-    def usd_settings(self): ...
+    def usd_settings(self):
+        """
+        :meta private:
+        """
     @usd_settings.setter
-    def usd_settings(self, value) -> None: ...
+    def usd_settings(self, value) -> None:
+        """
+        :meta private:
+        """
 
 @dataclasses.dataclass
 class MeshReloadingSettings:
+    '''
+    Settings used when reloading a mesh.
+
+    This corresponds to the mesh related options that are available in the
+    "Project configuration" dialog.
+
+    See also:
+        :func:`reload_mesh`,
+        `Project configuration documentation`_.
+
+    .. _Project configuration documentation:
+        https://www.adobe.com/go/painter-project-configuration
+
+    :param import_cameras: Import cameras from the mesh file.
+    :param preserve_strokes: Preserve strokes positions on mesh.
+    :param mesh_settings: Specific settings for USD files.
+    :param usd_settings: Deprecated, use mesh_settings instead.
+    '''
     import_cameras: bool = ...
     preserve_strokes: bool = ...
     mesh_settings: UsdSettings = ...
     @property
-    def usd_settings(self): ...
+    def usd_settings(self):
+        """
+        :meta private:
+        """
     @usd_settings.setter
-    def usd_settings(self, value) -> None: ...
+    def usd_settings(self, value) -> None:
+        """
+        :meta private:
+        """
 
 class _ActionLock:
+    """
+    Utility class to perform project operations which require locking the project first.
+    For some operations, such as :func:`save`, :func:`save_as_copy` and :func:`save_as_template`,
+    the project must be locked before the operation can be performed.
+    Once the operation is done, the project must be unlocked.
+    This class provides a context manager to make lock and unlock regardless of raised errors.
+
+    Example:
+        ::
+
+            with substance_painter.project._ActionLock():
+                _substance_painter.project.save()
+
+    """
     def __enter__(self): ...
     def __exit__(self, err_type: type[BaseException] | None, err_value: BaseException | None, traceback: types.TracebackType | None) -> None: ...
 
-def name() -> str | None: ...
-def file_path() -> str | None: ...
-def close() -> None: ...
-def open(project_file_path: str) -> None: ...
-def is_open() -> bool: ...
-def needs_saving() -> bool: ...
-def is_in_edition_state() -> bool: ...
-def is_busy() -> bool: ...
-def execute_when_not_busy(callback: Callable[[], None]) -> None: ...
-def save_as(project_file_path: str, mode: ProjectSaveMode = ...) -> None: ...
-def save(mode: ProjectSaveMode = ...) -> None: ...
-def save_as_copy(backup_file_path: str, mode: ProjectSaveMode = ...) -> None: ...
-def save_as_template(template_file_path: str, texture_set_name: str) -> ProjectSaveMode: ...
-def create(mesh_file_path: str, mesh_map_file_paths: list[str] = None, template_file_path: str = None, settings: Settings = ...): ...  # type: ignore[assignment]
-def last_imported_mesh_path() -> str: ...
-def last_saved_substance_painter_version() -> tuple[int, int, int] | None: ...
+def name() -> str | None:
+    """
+    Return the name of the current project.
+
+    Returns:
+        str: The name of the current project, or ``None`` if the project hasn't
+        been saved yet.
+
+    Raises:
+        ServiceNotFoundError: If Substance 3D Painter has not started all its services yet.
+        ProjectError: If no project is opened.
+    """
+def file_path() -> str | None:
+    """
+    Return the file path of the current project. This is the path where the
+    project will be written to when it is saved.
+
+    Returns:
+        str: The file path of the current project, or ``None`` if the project
+        hasn't been saved yet.
+
+    Raises:
+        ServiceNotFoundError: If Substance 3D Painter has not started all its services yet.
+        ProjectError: If no project is opened.
+
+    See also:
+        :func:`save`,
+        :func:`save_as`.
+    """
+def close() -> None:
+    """
+    Close the current project.
+
+    Warning:
+        Any unsaved data will be lost.
+
+    Raises:
+        ServiceNotFoundError: If Substance 3D Painter has not started all its services yet.
+        ProjectError: If no project is opened.
+    """
+def open(project_file_path: str) -> None:
+    """
+    Open the project located at ``project_file_path``.
+
+    Args:
+        project_file_path (str): The path to the project file (with the extension ``.spp``).
+
+    Raises:
+        ProjectError: If Substance 3D Painter cannot open the file ``project_file_path``.
+        ProjectError: If there is already an opened project.
+        ServiceNotFoundError: If Substance 3D Painter has not started all its services yet.
+    """
+def is_open() -> bool:
+    """
+    Check if a project is already opened.
+
+    Returns:
+        bool: ``True`` if a project is opened, ``False`` otherwise.
+
+    Raises:
+        ServiceNotFoundError: If Substance 3D Painter has not started all its services yet.
+    """
+def needs_saving() -> bool:
+    """
+    Check if the current project needs to be saved.
+
+    Raises:
+        ServiceNotFoundError: If Substance 3D Painter has not started all its services yet.
+        ProjectError: If no project is opened.
+
+    Returns:
+        bool: ``True`` if the project has modifications and needs to be saved,
+        ``False`` otherwise.
+    """
+def is_in_edition_state() -> bool:
+    """
+    Check if the current project is ready to work with.
+
+    Raises:
+        ServiceNotFoundError: If Substance 3D Painter has not started all its services yet.
+        ProjectError: If no project is opened.
+
+    Returns:
+        bool: ``True`` if the project is ready to work with,
+        ``False`` otherwise.
+
+    See also:
+        :class:`substance_painter.event.ProjectEditionEntered`,
+        :class:`substance_painter.event.ProjectEditionLeft`.
+    """
+def is_busy() -> bool:
+    """
+    Check if Substance 3D Painter is currently busy.
+    If busy, the project cannot be saved at the moment.
+    The application may be busy because no project is in edition state,
+    or a long process such as baking/export/unwrap process is ongoing.
+    The corresponding BusyStatusChanged event is fired when the busy state changes.
+
+    Returns:
+        bool: ``True`` if the project is ready to be saved,
+        ``False`` otherwise.
+
+    See also:
+        :func:`execute_when_not_busy`,
+        :class:`substance_painter.event.BusyStatusChanged`.
+    """
+def execute_when_not_busy(callback: Callable[[], None]) -> None:
+    """
+    Execute the given callback when Substance 3D Painter is not busy.
+
+    Args:
+        callback (Callable[[], None]): The callback to be executed.
+
+    See also:
+        :func:`is_busy`,
+        :class:`substance_painter.event.BusyStatusChanged`.
+    """
+def save_as(project_file_path: str, mode: ProjectSaveMode = ...) -> None:
+    """
+    Save the current project by writing it to the file path ``project_file_path``.
+
+    Note:
+        If the path ``project_file_path`` doesn't exist yet, new folders will be
+        created as needed.
+        Save is disabled when Substance 3D Painter is busy and will throw a ProjectError.
+
+    Args:
+        project_file_path (string): The file path to save the project to.
+        mode (ProjectSaveMode): The save mode (Incremental or Full).
+
+    Raises:
+        ProjectError: If Substance 3D Painter cannot save the project.
+        ProjectError: If no project is opened.
+        ServiceNotFoundError: If Substance 3D Painter has not started all its services yet.
+
+    See also:
+        :class:`ProjectSaveMode`,
+        :func:`save`,
+        :func:`save_as_copy`.
+        :func:`is_busy`.
+    """
+def save(mode: ProjectSaveMode = ...) -> None:
+    """
+    Save the current project by overwriting the previous save.
+
+    Note:
+        Save is disabled when Substance 3D Painter is busy and will throw a ProjectError.
+
+    Args:
+        mode (ProjectSaveMode): The save mode (Incremental or Full).
+
+    Raises:
+        ProjectError: If Substance 3D Painter cannot save the project.
+        ProjectError: If no project is opened.
+        ServiceNotFoundError: If Substance 3D Painter has not started all its services yet.
+
+    See also:
+        :class:`ProjectSaveMode`,
+        :func:`save_as`,
+        :func:`save_as_copy`.
+        :func:`is_busy`.
+    """
+def save_as_copy(backup_file_path: str, mode: ProjectSaveMode = ...) -> None:
+    """
+    Save a copy of the current project by writing it to the file path
+    ``backup_file_path``. This can be used to save backups of the opened project
+    without modifying the original file.
+
+    After `save_as_copy` the project is still considered to be located at the
+    location it was previously saved to. If the project was not saved, it is
+    still considered to not have a saved location.
+
+    Note:
+        If the path ``backup_file_path`` doesn't exist yet, new folders will be
+        created as needed.
+        Save is disabled when Substance 3D Painter is busy and will throw a ProjectError.
+
+    Args:
+        backup_file_path (string): The path to write the copy of the project to.
+        mode (ProjectSaveMode): The save mode (Incremental or Full).
+
+    Raises:
+        ProjectError: If Substance 3D Painter cannot save the copy.
+        ProjectError: If no project is opened.
+        ServiceNotFoundError: If Substance 3D Painter has not started all its services yet.
+
+    See also:
+        :class:`ProjectSaveMode`,
+        :func:`save`,
+        :func:`save_as`.
+        :func:`is_busy`.
+    """
+def save_as_template(template_file_path: str, texture_set_name: str) -> ProjectSaveMode:
+    """
+    Save a template based of the current Texture Set or the one specified.
+
+    Note:
+        New folders will be created if they are missing.
+        Save is disabled when Substance 3D Painter is busy and will throw a ProjectError.
+
+    Warning:
+        If the file already exists, it will be overwritten.
+
+    Args:
+        template_file_path (string): The save path.
+        texture_set_name (string): Name of the Texture Set used as a template.
+
+    Raises:
+        ProjectError: If Substance 3D Painter cannot save the template.
+        ProjectError: If no project is opened.
+        ServiceNotFoundError: If Substance 3D Painter has not started all its services yet.
+
+    See also:
+        :func:`is_busy`.
+    """
+def create(mesh_file_path: str, mesh_map_file_paths: list[str] = None, template_file_path: str = None, settings: Settings = ...):  # type: ignore[assignment]
+    """
+    Create a new project.
+    If an ``OCIO`` environment variable is set, pointing to a .ocio configuration file,
+    the project is setup to use the OCIO color management mode defined by that file.
+    If the configuration defined by that file is invalid, a ``ProjectError`` is raised and
+    no project is created.
+    Similary, if a ``PAINTER_ACE_CONFIG`` environment variable is set, pointing to a .json
+    preset file, the project is setup to use the ACE color management mode defined by that file.
+    If the preset defined in that file is invalid, a ``ProjectError`` is raised and no project
+    is created.
+    If both environment variables are set, ``OCIO`` will be used.
+    If there is not such environment variable, the project uses the Legacy color management mode.
+
+    Note:
+        Project settings override the template parameters.
+
+    Args:
+        mesh_file_path (string): File path of the mesh to edit.
+            Supported file formats: fbx, obj, dae, ply, usd.
+        mesh_map_file_paths (list of string): Paths to the additional mesh maps.
+        template_file_path (string): Template file path to use to create the project.
+        settings (Settings): Configuration options of the new project.
+
+    Raises:
+        ProjectError: If Substance 3D Painter cannot create the project.
+        ProjectError: If there is already an opened project.
+        ProjectError: If an ``OCIO`` environment variable is set to an invalid configuration.
+        ProjectError: If an ``PAINTER_ACE_CONFIG`` environment variable is set to an invalid preset.
+        ServiceNotFoundError: If Substance 3D Painter has not started all its services yet.
+        TypeError: If ``settings`` is not an instance of Settings.
+        ValueError: If the file format of ``mesh_file_path`` is not supported.
+        ValueError: If the mesh file ``mesh_file_path`` does not exist.
+        ValueError: If any of the mesh map files in ``mesh_map_file_paths`` do not exist.
+        ValueError: If the template file ``template_file_path`` doesn't exist.
+        ValueError: If the template file ``template_file_path`` is invalid.
+        ValueError: If ``settings`` are not valid project settings (see documentation
+            of :class:`Settings`).
+        ValueError: If ``settings.default_texture_resolution`` is not a valid resolution.
+
+    See also:
+        :class:`Settings`,
+        `Project creation documentation`_.
+
+    .. _Project creation documentation:
+        https://www.adobe.com/go/painter-project-creation
+    """
+def last_imported_mesh_path() -> str:
+    """
+    Return the path to the last imported mesh.
+
+    Returns:
+        str: The file path of the mesh that was last imported to the project.
+
+    Raises:
+        ProjectError: If no project is opened.
+        ServiceNotFoundError: If Substance 3D Painter has not started all its services yet.
+    """
+def last_saved_substance_painter_version() -> tuple[int, int, int] | None:
+    """
+    Return the version of Substance 3D Painter used to last save the project, or None
+    if the project is unsaved or was saved with version <= 8.2.0.
+
+    Returns:
+        Tuple(int, int, int): The concerned version of Substance 3D Painter, as a major/minor/patch
+        tuple.
+
+    Raises:
+        ProjectError: If no project is opened.
+        ServiceNotFoundError: If Substance 3D Painter has not started all its services yet.
+    """
 
 class ReloadMeshStatus(enum.Enum):
+    """
+    Reload mesh status, used in mesh reload asynchronous callback.
+
+    See also:
+        :func:`reload_mesh`,
+    """
     SUCCESS = 0
     ERROR = 2
 
-def reload_mesh(mesh_file_path: str, settings: MeshReloadingSettings, loading_status_cb: Callable[[ReloadMeshStatus], Any]): ...
+def reload_mesh(mesh_file_path: str, settings: MeshReloadingSettings, loading_status_cb: Callable[[ReloadMeshStatus], Any]):
+    """
+    Import a new mesh to the current project, using the given settings.
+    Uses the automatic UV unwrapping settings defined at the project level.
+
+    The loading is asynchronous: this function returns immediately; when
+    the loading attempt is finished ``loading_status_cb`` is called with
+    an argument indicating if loading was successful.
+
+    Args:
+        mesh_file_path (string): File path of the mesh to edit.
+            Supported file formats: fbx, obj, dae, ply, usd.
+        settings (MeshReloadingSettings): Configuration options for the mesh loading.
+        loading_status_cb (Callable[[ReloadMeshStatus], Any]): Loading status notification callback.
+
+    Raises:
+        ProjectError: If no project is opened or Substance 3D Painter is busy.
+        ServiceNotFoundError: If Substance 3D Painter has not started all its services yet.
+
+    See also:
+        :class:`ReloadMeshStatus`,
+        :class:`MeshReloadingSettings`,
+        :func:`is_busy`,
+        `Project creation documentation`_.
+
+    .. _Project creation documentation:
+        https://www.adobe.com/go/painter-project-creation
+    """
 
 @dataclasses.dataclass(frozen=True)
 class BoundingBox:
+    """
+    Axis-aligned bounding box (AABB).
+
+    :param dimensions: The dimensions (x,y,z) of the bounding box.
+    :param center: The center (x,y,z) of the bounding box..
+    :param radius: The radius of the bounding box.
+
+    See also:
+        :func:`get_scene_bounding_box`,
+    """
     dimensions: list[float]
     center: list[float]
     radius: float
 
-def get_scene_bounding_box() -> BoundingBox: ...
-def get_uuid() -> uuid.UUID: ...
+def get_scene_bounding_box() -> BoundingBox:
+    """
+    Return the bounding box of the scene.
+
+    Returns:
+        BoundingBox: The bounding box of the scene.
+
+    Raises:
+        ProjectError: If no project is opened.
+    """
+def get_uuid() -> uuid.UUID:
+    """
+    Return the UUID of the current project.
+
+    Returns:
+        uuid.UUID: The UUID of the current project.
+
+    Raises:
+        ProjectError: If no project is opened.
+    """
 
 class Metadata:
+    '''
+    Project metadata are arbitrary data that can be attached to a `Substance
+    Painter` project. When the project is saved, the metadata are saved with it,
+    so it is still available the next time the project is loaded.
+
+    Metadata can only be accessed when a project is opened. If no project is
+    opened, the methods will raise an exception.
+
+    The constructor of the class ``Metadata`` takes a context name as an
+    argument. This context name can be for example the name of your plugin. It
+    should be unique, to avoid conflict with other plugins.
+
+    Example:
+        ::
+
+            import substance_painter
+
+            # Instantiate the Metadata utility, for the plugin "MyPlugin".
+            metadata = substance_painter.project.Metadata("MyPlugin")
+
+            # Store a version number under the key "version".
+            plugin_version = { "major": 1, "minor": 0 }
+            metadata.set("version", plugin_version)
+
+            # List the project\'s metadata keys. The key "version" is now present.
+            keys = metadata.list()
+            print(keys)
+
+            # Retrieve the metadata "version".
+            plugin_version = metadata.get("version")
+            print("Version: " + str(plugin_version))
+    '''
     def __init__(self, context: str) -> None: ...
-    def list(self) -> list: ...
-    def get(self, key: str): ...
-    def set(self, key: str, value): ...
+    def list(self) -> list:
+        """
+        Return the list of project metadata keys.
+
+        Raises:
+            ProjectError: If no project is opened.
+            ServiceNotFoundError: If Substance 3D Painter has not started all its services yet.
+        """
+    def get(self, key: str):
+        """
+        Retrieve the project metadata under the given key.
+
+        The supported data types are:
+            - Primitive types: `bool`, `int`, `float`, `str`.
+            - `list`
+               - Items can be any of the supported data types.
+            - `dict`
+               - Keys must be of type `str`.
+               - Values can be any of the supported data types.
+
+        Args:
+            key (str): The key identifying the metadata to retrieve.
+
+        Raises:
+            ProjectError: If no project is opened.
+            RuntimeError: If the metadata under ``key`` use a type that is not supported.
+            ServiceNotFoundError: If Substance 3D Painter has not started all its services yet.
+        """
+    def set(self, key: str, value):
+        """
+        Store project metadata under the given key.
+
+        The supported data types are:
+            - Primitive types: `bool`, `int`, `float`, `str`.
+            - `list`
+               - Items can be any of the supported data types.
+            - `dict`
+               - Keys must be of type `str`.
+               - Values can be any of the supported data types.
+
+        Args:
+            key (str): The key identifying the metadata to store.
+            value: The metadata to store.
+
+        Raises:
+            ProjectError: If no project is opened.
+            RuntimeError: If ``value`` uses a type that is not supported.
+            ServiceNotFoundError: If Substance 3D Painter has not started all its services yet.
+        """

--- a/substance_painter/stubs/substance_painter-stubs/properties.pyi
+++ b/substance_painter/stubs/substance_painter-stubs/properties.pyi
@@ -7,12 +7,71 @@ PropertyValue = bool | int | tuple[int, int] | tuple[int, int, int] | tuple[int,
 
 @dataclasses.dataclass(frozen=True)
 class Property:
+    """
+    Read only access to a property data.
+    """
     handle: _substance_painter.data_tweak.PythonTweak
-    def value(self) -> PropertyValue: ...
-    def name(self) -> str: ...
-    def short_name(self) -> str: ...
-    def label(self) -> str: ...
-    def widget_type(self) -> str: ...
-    def enum_values(self) -> dict[str, int]: ...
-    def enum_value(self, enum_label: str) -> int: ...
-    def properties(self) -> dict[str, typing.Any]: ...
+    def value(self) -> PropertyValue:
+        """
+        Get the current property value.
+
+        Returns:
+            PropertyValue: the current value.
+        """
+    def name(self) -> str:
+        """
+        Get the property name.
+
+        Returns:
+            str: The property name.
+        """
+    def short_name(self) -> str:
+        """
+        Get the shortened property name.
+
+        Returns:
+            str: The property short name.
+        """
+    def label(self) -> str:
+        """
+        Get the property label.
+
+        Returns:
+            str: The property label.
+        """
+    def widget_type(self) -> str:
+        """
+        Get the widget type that should be used to edit the property.
+
+        Returns:
+            str: One of: 'Slider', 'Angle', 'Color', 'Togglebutton',
+            'Combobox', 'RandomSeed', 'File', 'FileList', 'LineEdit',
+            'Resource', 'TextEdit'.
+        """
+    def enum_values(self) -> dict[str, int]:
+        """
+        The possible enum values with corresponding text for 'Combobox'
+        widget type.
+
+        Returns:
+            typing.Dict[str, int]: Enum label to enum value dictionary.
+        """
+    def enum_value(self, enum_label: str) -> int:
+        """
+        Get the enum value for the given enum label for 'Combobox'
+        widget type.
+
+        Args:
+            enum_label (str): A valid enum label.
+
+        Returns:
+            typing.Dict[str, int]: The enum value for the corresponding label.
+        """
+    def properties(self) -> dict[str, typing.Any]:
+        """
+        Get a json object that describes all available meta properties of this
+        property. For example: value range, editor step, possible values, tooltip, etc.
+
+        Returns:
+            typing.Dict[str, typing.Any]: A json object.
+        """

--- a/substance_painter/stubs/substance_painter-stubs/resource.pyi
+++ b/substance_painter/stubs/substance_painter-stubs/resource.pyi
@@ -1,27 +1,173 @@
 import _substance_painter.resource
 import dataclasses
 import enum
+from _typeshed import Incomplete
 
 class ResourceLocation(enum.Enum):
+    '''Each resource has a location determined by where its data lives.
+
+    Members:
+
+    =========== ====================
+    Name        Data location
+    =========== ====================
+    ``SESSION`` Current session; those ressources will be lost after a restart of the application.
+    ``PROJECT`` A Substance 3D Painter project; those resources are embedded in the spp file.
+    ``SHELF``   One of the Substance 3D Painter Shelves.
+    =========== ====================
+
+    Example:
+        ::
+
+            import substance_painter.resource
+
+            # For a resource from the default shelf
+            aluminium = substance_painter.resource.ResourceID(
+                context="starter_assets", name="Aluminium Insulator");
+
+            # This will print:
+            # ResourceLocation.SHELF
+            print(aluminium.location())
+
+            # For an embedded resource, like a baked map
+            aomap = substance_painter.resource.ResourceID.from_project(
+                name="ambient_occlusion");
+
+            # This will print:
+            # ResourceLocation.PROJECT
+            print(aomap.location())
+
+            # Finally, for a temporary resource
+            test_envmap = substance_painter.resource.ResourceID.from_session(
+                name="Test Envmap");
+
+            # This will print:
+            # ResourceLocation.SESSION
+            print(test_envmap.location())
+
+    '''
     SESSION = ...
     PROJECT = ...
     SHELF = ...
 
 @dataclasses.dataclass(frozen=True)
 class ResourceID:
+    """
+    A `Substance 3D Painter` resource identifier.
+
+    The resource is identified by a context, a name, and a version. The context
+    and the name are mandatory while the version is optional. The version is a
+    string that looks like a hash, and may also contain an extension.
+
+    Note:
+        A ResourceID object is only an identifier. It provides no guarantees that
+        the resource actually exists.
+
+    See also:
+        :mod:`substance_painter.display`.
+    """
     context: str
     name: str
     version: str = ...
     @classmethod
-    def from_url(cls, url: str): ...
+    def from_url(cls, url: str):
+        """
+        Create a `ResourceID` object from its URL.
+        URLs must have ``resource://`` as a scheme. The version is encoded as a query
+        string, that looks like a hash.
+
+        A resource URL looks like this:
+
+        ``resource://context/name?version=0123456789abcdef0123456789abcdef01234567.image``
+
+        Args:
+            url (str): The resource URL.
+
+        Returns:
+            ResourceID: The resource corresponding to the given URL.
+
+        Raises:
+            ValueError: If ``url`` is not a valid URL.
+            ValueError: If the URL scheme is not ``resource://``.
+            ValueError: If the resource name is invalid.
+        """
     @classmethod
-    def from_project(cls, name: str, version: str = None): ...  # type: ignore[assignment]
+    def from_project(cls, name: str, version: str = None):  # type: ignore[assignment]
+        """
+        Create a `ResourceID` object for a resource located in the current project.
+
+        Args:
+            name (str): The resource name.
+            version (str, optional): The resource version (hash-like string).
+
+        Returns:
+            ResourceID: The resource corresponding to the given name.
+        """
     @classmethod
-    def from_session(cls, name: str, version: str = None): ...  # type: ignore[assignment]
-    def url(self) -> str: ...
-    def location(self) -> ResourceLocation: ...
+    def from_session(cls, name: str, version: str = None):  # type: ignore[assignment]
+        """
+        Create a `ResourceID` object for a resource located in the current session.
+
+        Args:
+            name (str): The resource name.
+            version (str, optional): The resource version (hash-like string).
+
+        Returns:
+            ResourceID: The resource corresponding to the given name.
+        """
+    def url(self) -> str:
+        """
+        Get the URL form of this `ResourceID`.
+
+        Returns:
+            str: The URL of the resource.
+
+        Raises:
+            ValueError: If the `ResourceID` doesn't have a context.
+            ValueError: If the `ResourceID` doesn't have a name.
+        """
+    def location(self) -> ResourceLocation:
+        """
+        Get the location of this `ResourceID`.
+
+        Returns:
+            ResourceLocation: The location of this resource.
+        """
 
 class Usage(enum.Enum):
+    """
+    Enumeration describing how a given resource is meant to be used.
+
+    Members:
+
+    ===================== ====================
+    Name                  Usage
+    ===================== ====================
+    ``ALPHA``             A brush alpha.
+    ``BASE_MATERIAL``     A material.
+    ``BRUSH``             A brush definition.
+    ``COLOR_LUT``         A color look-up table.
+    ``EMITTER``           A particle emitter script.
+    ``ENVIRONMENT``       An environment map.
+    ``EXPORT``            An export preset.
+    ``FILTER``            A layer stack filter.
+    ``FONT``              A text font.
+    ``GENERATOR``         A mask generator.
+    ``PARTICLE``          A particles effect.
+    ``PROCEDURAL``        A procedural substance, like a noise.
+    ``RECEIVER``          A particle receiver script.
+    ``SHADER``            A shader.
+    ``SMART_MASK``        A smart mask.
+    ``SMART_MATERIAL``    A smart material.
+    ``TEXTURE``           A UV space map like bakes.
+    ``TOOL``              A painting tool preset.
+    ===================== ====================
+
+    See also:
+        :func:`import_project_resource`,
+        :func:`import_session_resource`,
+        :meth:`Shelf.import_resource`.
+    """
     ALPHA = ...
     BASE_MATERIAL = ...
     BRUSH = ...
@@ -42,6 +188,30 @@ class Usage(enum.Enum):
     TOOL = ...
 
 class Type(enum.Enum):
+    """
+    Enumeration describing the type of a given resource.
+
+    Members:
+
+    ===================== ====================
+    Name                  Usage
+    ===================== ====================
+    ``ABR_PACKAGE``       A photoshop brushes package.
+    ``BRUSH``             A brush.
+    ``EXPORT``            An export preset.
+    ``FONT``              A text font.
+    ``IMAGE``             An image.
+    ``PRESET``            A resource preset.
+    ``RESOURCE``          A resource.
+    ``SCRIPT``            A particle emitter script.
+    ``SHADER``            A shader.
+    ``SMART_MASK``        A smart mask.
+    ``SMART_MATERIAL``    A smart material.
+    ``SUBSTANCE``         A substance.
+    ``SUBSTANCE_PACKAGE`` A substance package.
+    ``VECTORIAL``         A vectorial image.
+    ===================== ====================
+    """
     ABR_PACKAGE = ...
     BRUSH = ...
     EXPORT = ...
@@ -59,60 +229,804 @@ class Type(enum.Enum):
 
 @dataclasses.dataclass(frozen=True)
 class Resource:
+    """
+    A `Substance 3D Painter` resource.
+    """
     handle: _substance_painter.resource.ResourceHandle
-    def __eq__(self, other): ...
-    def __hash__(self): ...
-    def identifier(self) -> ResourceID: ...
-    def location(self) -> ResourceLocation: ...
-    @staticmethod
-    def retrieve(identifier: ResourceID): ...
-    def set_custom_preview(self, preview_image: str) -> None: ...
-    def category(self) -> str: ...
-    def usages(self) -> list[Usage]: ...
-    def gui_name(self) -> str: ...
-    def type(self) -> Type: ...
-    def tags(self) -> list[str]: ...
-    def internal_properties(self) -> dict: ...
-    def children(self) -> list['Resource']: ...
-    def parent(self) -> Resource | None: ...
-    def reset_preview(self) -> None: ...
-    def show_in_ui(self) -> None: ...
+    def __eq__(self, other):
+        """Compare inner handles"""
+    def __hash__(self):
+        """Hash based on inner handle"""
+    def identifier(self) -> ResourceID:
+        """
+        Get this resource identifier.
 
-def show_resources_in_ui(resources: list[Resource]) -> None: ...
-def import_project_resource(file_path: str, resource_usage: Usage, name: str = None, group: str = None) -> Resource: ...  # type: ignore[assignment]
-def import_session_resource(file_path: str, resource_usage: Usage, name: str = None, group: str = None) -> Resource: ...  # type: ignore[assignment]
+        Returns:
+            ResourceID: The resource identifier.
+
+        Raises:
+            RuntimeError: If the resource is invalid.
+
+        See also:
+            :class:`ResourceID`.
+        """
+    def location(self) -> ResourceLocation:
+        """
+        Get the location of this `Resource`.
+
+        Returns:
+            ResourceLocation: The location of this resource.
+
+        Raises:
+            RuntimeError: If the resource is invalid.
+        """
+    @staticmethod
+    def retrieve(identifier: ResourceID):
+        """
+        Retrieve a list of resources matching the given identifier.
+
+        Args:
+            identifier (ResourceID): A resource identifier.
+
+        Raises:
+            ValueError: If the name of the identifier is empty
+                or if the context of the identifier doesn't exists.
+            ServiceNotFoundError: If Substance 3D Painter has not started all its
+                services yet.
+
+        Returns:
+            typing.List[Resource]: The list of resources matching the given identifier.
+            If the identifier has a valid version, this method will return only one or
+            zero resources, otherwise the list may contain several resources. In case
+            of several resources are returned, the most up to date resource will be at
+            the begining of the list.
+        """
+    def set_custom_preview(self, preview_image: str) -> None:
+        """
+        Replace the current preview of this resource with a custom image.
+
+        Args:
+            preview_image (str): File path to an image on the disk to use as the new
+                preview.
+
+        Raises:
+            ValueError: If the resource metadata cannot be modified.
+            ValueError: If ``preview_image`` is not a valid path to a valid image.
+            ServiceNotFoundError: If Substance 3D Painter has not started all its
+                services yet.
+
+        Note:
+            The preview image can be a JPEG, a PNG or an XPM.
+        """
+    def category(self) -> str:
+        '''
+        Get the category of this resource, ex: "wood" for a material.
+
+        Raises:
+            RuntimeError: If the resource is invalid.
+
+        Returns:
+            str: the category of this resource
+        '''
+    def usages(self) -> list[Usage]:
+        """
+        Get the usages of this resource.
+
+        Raises:
+            RuntimeError: If the resource is invalid.
+
+        Returns:
+            typing.List[Usage]: the usages of this resource
+
+        See also:
+            :class:`Usage`
+        """
+    def gui_name(self) -> str:
+        """
+        Get the GUI name of this resource.
+
+        Raises:
+            RuntimeError: If the resource is invalid.
+
+        Returns:
+            str: the GUI name of this resource
+        """
+    def type(self) -> Type:
+        """
+        Get the type of this resource.
+
+        Raises:
+            RuntimeError: If the resource is invalid.
+
+        Returns:
+            Type: the type of this resource
+
+        See also:
+            :class:`Type`
+        """
+    def tags(self) -> list[str]:
+        """
+        Get the tags of this resource.
+
+        Raises:
+            RuntimeError: If the resource is invalid.
+
+        Returns:
+            typing.List[str]: the tags of this resource
+        """
+    def internal_properties(self) -> dict:
+        """
+        Get a dictionnary of the resource internal properties.
+        The current implementation only extracts metadata on Substance resources.
+
+        Raises:
+            RuntimeError: If the resource is invalid.
+
+        Returns:
+            dict: a dictionnary containing internal properties about this resource
+        """
+    def children(self) -> list['Resource']:
+        """
+        Get child resources.
+        For example substance graphs of a substance package.
+
+        Raises:
+            RuntimeError: If the resource is invalid.
+
+        Returns:
+            typing.List[Resource]: Resources contained in this resource.
+        """
+    def parent(self) -> Resource | None:
+        """
+        Get parent resource.
+        For example the substance package a substance graph is originating from.
+
+        Raises:
+            RuntimeError: If the resource is invalid.
+
+        Returns:
+            typing.Optional[Resource]: The parent resource that owns this resource.
+        """
+    def reset_preview(self) -> None:
+        """
+        Remove any custom preview for this resource and resets to the default one.
+
+        Raises:
+            ValueError: If the resource metadata cannot be modified.
+            ServiceNotFoundError: If Substance 3D Painter has not started all its
+                services yet.
+        """
+    def show_in_ui(self) -> None:
+        """
+        Highlight this resource in the application shelf UI (Assets window).
+
+        Raises:
+            ServiceNotFoundError: If Substance 3D Painter has not started all its
+                services yet.
+
+        See also:
+            :func:`show_resources_in_ui`.
+        """
+
+def show_resources_in_ui(resources: list[Resource]) -> None:
+    """
+    Highlight a list of resources in the application shelf UI (Assets window).
+
+    Args:
+        resources (List[Resource]): Resources to highlight
+
+    Raises:
+        ServiceNotFoundError: If Substance 3D Painter has not started all its
+            services yet.
+
+    See also:
+        :func:`Resource.show_in_ui`.
+    """
+def import_project_resource(file_path: str, resource_usage: Usage, name: str = None, group: str = None) -> Resource:  # type: ignore[assignment]
+    """
+    Import a resource into the current opened project.
+
+    Args:
+        file_path (str): The file path to the resource to be imported.
+        resource_usage (Usage): The resource usage.
+        name (str, optional): The name of the resource if different from the
+            file name.
+        group (str, opional): An optional group name, can be used in resource
+            queries.
+
+    Returns:
+        Resource: The imported resource object.
+
+    Raises:
+        ProjectError: If no project is opened.
+        ValueError: If parameters validation failed.
+        RuntimeError: If import failed.
+        ServiceNotFoundError: If Substance 3D Painter has not started all its
+            services yet.
+    """
+def import_session_resource(file_path: str, resource_usage: Usage, name: str = None, group: str = None) -> Resource:  # type: ignore[assignment]
+    """
+    Import a resource into the current session.
+
+    Args:
+        file_path (str): The file path to the resource to be imported.
+        resource_usage (Usage): The resource usage.
+        name (str, optional): The name of the resource if different from the
+            file name.
+        group (str, opional): An optional group name, can be used in resource
+            queries.
+
+    Returns:
+        Resource: The imported resource object.
+
+    Raises:
+        ValueError: If parameters validation failed.
+        RuntimeError: If import failed.
+        ServiceNotFoundError: If Substance 3D Painter has not started all its
+            services yet.
+    """
 
 class StandardQuery:
+    """
+    Standard resource queries.
+
+    Members:
+
+    ====================== ====================
+    Name                   Query
+    ====================== ====================
+    ``ALL_RESOURCES``      All resources.
+    ``PROJECT_RESOURCES``  Resources that belongs to the current project.
+    ``SESSION_RESOURCES``  Resources that belongs to the current session.
+    ``SHELVES_RESOURCES``  All shelves resources.
+    ====================== ====================
+
+    See also:
+        :func:`search`.
+    """
     ALL_RESOURCES: str
     PROJECT_RESOURCES: str
     SESSION_RESOURCES: str
     SHELVES_RESOURCES: str
 
-def search(query: str) -> list[Resource]: ...
-def list_layer_stack_resources() -> list[ResourceID]: ...
-def update_layer_stack_resource(old_resource_id: ResourceID, new_resource: Resource) -> list[ResourceID]: ...
+def search(query: str) -> list[Resource]:
+    """
+    List Substance 3D Painter resources that match the given query.
+
+    Args:
+        query (str): A resource query string. See `text query documentation`_.
+
+    Returns:
+        List[Resource]: The list of resources that match the given query.
+
+    Raises:
+        ServiceNotFoundError: If Substance 3D Painter has not started all its
+            services yet.
+
+    See also:
+        :class:`StandardQuery`.
+
+    .. _text query documentation:
+        https://www.adobe.com/go/painter-filtering-shelf-content
+    """
+def list_layer_stack_resources() -> list[ResourceID]:
+    """
+    List the resources referenced by the layer stacks and mesh maps of the current
+    project.
+
+    Returns:
+        List[ResourceID]: The list of resource identifiers referenced.
+
+    Raises:
+        ProjectError: If no project is opened.
+        ServiceNotFoundError: If Substance 3D Painter has not started all its
+            services yet.
+
+    Warning:
+        Deprecated since 0.3.4, use :func:`list_project_resources` instead.
+
+    See also:
+        :func:`update_layer_stack_resource`,
+        :mod:`substance_painter.display`.
+    """
+def update_layer_stack_resource(old_resource_id: ResourceID, new_resource: Resource) -> list[ResourceID]:
+    """
+    Replace resources from the layer stacks and mesh maps in the current project.
+
+    Given a resource identifier, replace any resource having the same identifier
+    with the new resource. The new resource must be compatible with the ones it
+    replaces (see note); otherwise, an error is thrown.
+
+    Note:
+        The new resource must be of the same type as the resources it replaces.
+        For example a base material resource cannot be updated with a vectorial resource.
+
+        Moreover:
+
+        - If the resource is a Substance material, it must have the same number
+          and names of outputs.
+        - If the resource is a Substance filter, it must have the same number
+          and names of inputs and outputs.
+
+    Returns:
+        List[ResourceID]: The list of identifiers of all the resources that have
+        been replaced.
+
+    Args:
+        old_resource_id (ResourceID): The identifier of the resource(s) to update.
+        new_resource (Resource): The new resource to use instead.
+
+    Raises:
+        ProjectError: If no project is opened.
+        TypeError: If ``old_resource_id`` is not a ResourceID.
+        TypeError: If ``new_resource`` is not a Resource.
+        RuntimeError: If ``new_resource`` is not a valid resource.
+        RuntimeError: If ``new_resource`` cannot be used in place of
+            ``old_resource_id``.
+        ServiceNotFoundError: If Substance 3D Painter has not started all its
+            services yet.
+
+    Warning:
+        Using this function in a loop to replace a lot of resources can be time-consuming and
+        can cause a temporary freeze of the application. See
+        :func:`replace_project_resources` which is more efficient.
+
+    Warning:
+        Deprecated since 0.3.4, use :func:`replace_project_resources` instead.
+
+    See also:
+        :func:`list_layer_stack_resources`,
+        :class:`Usage`,
+        :mod:`substance_painter.display`.
+    """
+def list_project_resources() -> list[ResourceID]:
+    """
+    List the resources used in the current project. Project resources are all
+    the resources used in the project (in the layerstack, shaders, environment map, etc.).
+
+    Returns:
+        List[ResourceID]: The list of resource identifiers.
+
+    Raises:
+        ProjectError: If no project is opened.
+        ServiceNotFoundError: If Substance 3D Painter has not started all its
+            services yet.
+
+    See also:
+        :func:`replace_project_resources`.
+    """
+def list_project_outdated_resources() -> dict[ResourceID, ResourceID]:
+    """
+    List the resources used in the current project that are outdated. Project resources are all
+    the resources used in the project (in the layerstack, shaders, environment map, etc.).
+    An outdated resource is a resource that has been reloaded in the application, but not yet
+    updated in the project.
+
+    Returns:
+        Dict[ResourceID,ResourceID]: A dictionary with the old resources identifier as key and
+        the new resources identifier as value.
+
+    Raises:
+        ProjectError: If no project is opened.
+        ServiceNotFoundError: If Substance 3D Painter has not started all its
+            services yet.
+
+    See also:
+        :func:`replace_project_resources`.
+    """
+
+from _substance_painter.resource import UpdateProjectStatus as UpdateProjectStatus  # type: ignore[attr-defined]
+
+@dataclasses.dataclass(frozen=True)
+class UpdateProjectError:
+    """
+    Error that occurred during the :func:`replace_project_resources` operation.
+
+    :param old_id: The identifier of the resource that could not be updated.
+    :param new_id: The identifier of the resource that was supposed to replace the old one.
+    :param details: A list of errors messages.
+
+    See also:
+        :func:`replace_project_resources`, :class:`UpdateProjectResult`.
+    """
+    old_resource_id: ResourceID
+    new_resource_id: ResourceID
+    details: list[str]
+
+@dataclasses.dataclass(frozen=True)
+class UpdateProjectResult:
+    """
+    Result of the :func:`replace_project_resources` operation.
+
+    :param status: The status of the operation.
+    :param errors: A list of errors if the operation failed. If the operation
+        was successful, this list is empty.
+
+    See also:
+        :func:`replace_project_resources`, :class:`UpdateProjectStatus`,
+        :class:`UpdateProjectError`.
+    """
+    status: UpdateProjectStatus
+    errors: list[UpdateProjectError]
+
+def replace_project_resources(ids: dict[ResourceID, ResourceID], allow_parameters_mismatch: bool = False) -> UpdateProjectResult:
+    """
+    Replace resources in the current project. Project resources are all
+    the resources used in the project (in the layerstack, shaders, environment map, etc.).
+
+    Given a pair of resource identifiers:
+
+    - the first element is the old resource identifier used in the project,
+    - the second element is the new resource identifier to use instead.
+
+    The operation will replace any resource having the same identifier
+    with the new resource. The new resource must be compatible with the ones it
+    replaces (see note); otherwise, the operation will fail.
+
+    If an error occurs during the update, no operation is performed on the project
+    and the :class:`UpdateProjectStatus` provides a list of errors.
+
+    Note:
+        The new resource must be of the same type as the resources it replaces.
+        For example a :class:`SUBSTANCE<Type>` resource cannot be updated with
+        a :class:`VECTORIAL<Type>` resource.
+
+        For more details on the rules to replace a resource, see the `Auto-Update documentation`_
+
+    .. _Auto-Update documentation:
+        https://www.adobe.com/go/painter-auto-update
+
+    Args:
+        ids (Dict[ResourceID, ResourceID]): A dictionary of resource identifiers
+            to update (key: old, value: new).
+            The dictionary must contain valid :class:`ResourceID`. If any resource identifier is
+            invalid or if the key does not correspond to an existing resource
+            in the project, the operation will fail.
+            If the dictionary is empty, no operation is performed.
+        allow_parameters_mismatch (bool, optional): By default (``False``), prevents resources with
+            parameters (e.g., .sbsar, .ai files) used in the project from updating if parameters
+            have been renamed or removed in the new version, so as to avoid unintended changes to
+            the texturing results. If any parameter mismatch is detected, the operation will fail.
+            If ``True``, any unmatched parameters will reset to their default values.
+
+    Returns:
+        UpdateProjectResult: The result of the operation.
+
+    Raises:
+        ProjectError: If no project is opened.
+        RuntimeError: If the application is not in Painting mode.
+        ServiceNotFoundError: If Substance 3D Painter has not started all its
+            services yet.
+
+    Warning:
+        This operation can be time-consuming if many resources are replaced or if the resources
+        are used a lot in the project. It can cause a temporary freeze of the application.
+        To avoid this issue, it is recommanded to split the operation in several batches.
+
+    See also:
+        :func:`list_project_resources`, :func:`list_project_outdated_resources`,
+        :class:`UpdateProjectResult`, `Auto-Update documentation`_.
+    """
 
 @dataclasses.dataclass(frozen=True)
 class Shelf:
-    def name(self) -> str: ...
-    def path(self) -> str: ...
-    def resources(self, query: str = ...) -> list[Resource]: ...
-    def can_import_resources(self) -> bool: ...
-    def import_resource(self, file_path: str, resource_usage: Usage, name: str = None, group: str = None, uuid: str = None) -> Resource: ...  # type: ignore[assignment]
-    def is_crawling(self) -> bool: ...
+    """
+    Class providing information on a given `Substance 3D Painter` shelf. A shelf
+    is identified by a unique `name`.
+    """
+    def name(self) -> str:
+        """
+        Returns:
+            The shelf name.
+            Each shelf is identified by a unique `name`.
+        """
+    def path(self) -> str:
+        """
+        Returns:
+            The associated path
+
+        Raises:
+            ValueError: If the shelf doesn't exist anymore.
+            ServiceNotFoundError: If Substance 3D Painter has not started all its
+                services yet.
+        """
+    def resources(self, query: str = ...) -> list[Resource]:
+        """
+        Get resources contained in this shelf. An optional query string can be given
+        to narrow the results.
+
+        Args:
+            query (str, optional): A resource query string.
+
+        Returns:
+            This shelf's list of resources.
+
+        See also:
+            :func:`search`.
+        """
+    def can_import_resources(self) -> bool:
+        """
+        Check if resources can be imported into this shelf.
+        Resources can be imported into a shelf, as long as it is not a read-only shelf.
+        The Substance shelf, installed along the application, is read-only. A shelf is
+        also read-only if its path on the file system is read-only.
+
+        Returns:
+            bool: ``True`` if resources can be imported.
+
+        Raises:
+            ServiceNotFoundError: If Substance 3D Painter has not started all its
+                services yet.
+
+        See also:
+            :class:`substance_painter.event.ShelfCrawlingEnded`.
+        """
+    def import_resource(self, file_path: str, resource_usage: Usage, name: str = None, group: str = None, uuid: str = None) -> Resource:  # type: ignore[assignment]
+        """
+        Import a resource into this shelf.
+
+        Args:
+            file_path (str): The file path to the resource to be imported.
+            resource_usage (Usage): The resource usage.
+            name (str, optional): The name of the resource if different from the
+                file name.
+            group (str, opional): An optional group name, can be used in resource
+                queries.
+            uuid (str, opional): An optional uuid. If a resource already exists with
+                the same uuid, it will be replaced.
+
+        Returns:
+            Resource: The imported resource object.
+
+        Raises:
+            ValueError: If parameters validation failed.
+            RuntimeError: If import failed.
+            ServiceNotFoundError: If Substance 3D Painter has not started all its
+                services yet.
+        """
+    def is_crawling(self) -> bool:
+        """
+        Check if this shelf is currently discovering resources in folders.
+
+        Returns:
+            bool: ``True`` if this shelf is discovering resources, ``False`` otherwise.
+
+        Raises:
+            ServiceNotFoundError: If Substance 3D Painter has not started all its
+                services yet.
+
+        See also:
+            :class:`substance_painter.event.ShelfCrawlingEnded`.
+        """
+    def refresh(self) -> None:
+        """
+        Forces discovering of resources in shelf folders.
+        Discovering is also done automatically when the application window gets focus.
+
+        Raises:
+            ServiceNotFoundError: If Substance 3D Painter has not started all its services yet.
+        """
 
 class Shelves:
+    """
+    Collection of static methods to manipulate shelves.
+    """
     @staticmethod
-    def all() -> list[Shelf]: ...
+    def all() -> list[Shelf]:
+        """
+        List all shelves.
+
+        Returns:
+            typing.List[Shelf]: List of existing shelves.
+
+        Raises:
+            ServiceNotFoundError: If Substance 3D Painter has not started all its
+                services yet.
+        """
     @staticmethod
-    def exists(name: str) -> bool: ...
+    def exists(name: str) -> bool:
+        """
+        Tell whether a shelf with the given name exists.
+
+        Args:
+            name (str): Shelf name to searh for.
+
+        Returns:
+            bool: ``True`` if a shelf with the given name exists.
+
+        Raises:
+            ServiceNotFoundError: If Substance 3D Painter has not started all its
+                services yet.
+        """
     @staticmethod
-    def add(name: str, path: str) -> Shelf: ...
+    def add(name: str, path: str) -> Shelf:
+        """
+        Add a new shelf. This shelf will only be valid during the application session.
+        The shelf will not be visible from application general settings menu.
+
+        Args:
+            name (str): Name of the new shelf. This name must be unique and must only
+                contain lowercase letters, numbers, underscores or hyphens.
+                Use :func:`Shelves.exists` to check if name is already used.
+            path (str): Folder path to monitor.
+
+        Returns:
+            Shelf: Newly added shelf.
+
+        Raises:
+            ValueError: If ``name`` or ``str`` are invalid. See logs for details.
+            ServiceNotFoundError: If Substance 3D Painter has not started all its
+                services yet.
+
+        See also:
+            :meth:`Shelves.exists`.
+            :meth:`Shelf.refresh`.
+        """
     @staticmethod
-    def remove(name: str): ...
+    def remove(name: str):
+        """
+        Removes a shelf.
+        No project must be opened.
+        Deleting a shelf which was not created by the Python API is not possible and
+        will raise an exception.
+
+        Args:
+            name (str): Name of the shelf to delete.
+                Use :meth:`Shelves.exists` to check if a shelf exists.
+
+        Raises:
+            ProjectError: If a project is opened.
+            ValueError: If the shelf doesn't exist.
+            ValueError: If the shelf was not created with the Python API.
+            ServiceNotFoundError: If Substance 3D Painter has not started all its
+                services yet.
+
+        See also:
+            :meth:`Shelves.exists`.
+        """
     @staticmethod
-    def refresh_all() -> None: ...
+    def refresh_all() -> None:
+        """
+        Forces discovering of resources in all shelves folders.
+        Discovering is also done automatically when the application window gets focus.
+
+        Raises:
+            ServiceNotFoundError: If Substance 3D Painter has not started all its
+                services yet.
+
+        See also:
+            :meth:`Shelf.refresh`.
+        """
     @staticmethod
-    def user_shelf() -> Shelf: ...
+    def user_shelf() -> Shelf:
+        """
+        This is the shelf located in the user Documents folder where new resources
+        are created by default. The user can select a different default shelf in the
+        settings, and this will be reflected when using this function.
+
+        Raises:
+            ServiceNotFoundError: If Substance 3D Painter has not started all its
+                services yet.
+
+        See also:
+            `Default shelf documentation`_.
+
+        .. _Default shelf documentation:
+            https://docs.substance3d.com/spdoc/shelf-configuration-124059665.html
+        """
     @staticmethod
-    def application_shelf() -> Shelf: ...
+    def application_shelf() -> Shelf:
+        """
+        This is the shelf containing the default content shipped with the application.
+        """
+
+@dataclasses.dataclass
+class AllResourcesFilter:
+    """
+    Filter used to reload all modified resources known to Substance 3D Painter, which includes
+    resources in all shelves, session-scoped resources, and project-scoped resources.
+
+    See also:
+        :func:`reload_modified_resources_async`
+    """
+@dataclasses.dataclass
+class ProjectFilter:
+    """
+    Filter used to reload modified resources contained in the project context.
+    This does not include resources used by the project (in the layerstack, shaders, environment
+    map, etc.) if they are contained in a shelf or the session.
+
+    See also:
+        :func:`reload_modified_resources_async`
+    """
+
+@dataclasses.dataclass
+class ResourcesListFilter:
+    """
+    Filter used to reload modified resources amongst a given list of resources.
+
+    :param resources: The list of reources to reload.
+
+    See also:
+        :func:`reload_modified_resources_async`
+    """
+    resources: list[ResourceID]
+
+@dataclasses.dataclass
+class ResourcesUsedByProjectFilter:
+    """
+    Filter used to reload modified resources currently in use by the project.
+    This includes resources from any contexts (project, shelves, session), as long as they are
+    currently referenced by the project.
+
+    See also:
+        :func:`reload_modified_resources_async`
+    """
+@dataclasses.dataclass
+class SessionFilter:
+    """
+    Filter used to reload modified resources contained in the session.
+
+    See also:
+        :func:`reload_modified_resources_async`
+    """
+
+@dataclasses.dataclass
+class ShelvesListFilter:
+    """
+    Filter used to reload modified resources contained in designated shelves.
+
+    :param shelves: The list of Shelves to reload.
+
+    See also:
+        :func:`reload_modified_resources_async`
+    """
+    shelves: list[Shelf]
+ReloadResourcesFilter = AllResourcesFilter | ProjectFilter | ResourcesListFilter | ResourcesUsedByProjectFilter | SessionFilter | ShelvesListFilter
+
+def reload_modified_resources_async(resource_filter: ReloadResourcesFilter) -> bool:
+    """
+    Triggers a reload of the modified resources found using the given filter. Outdated resources
+    are excluded.
+
+    If a reload operation is already running, this function will return ``False``.
+    One can check if a reload operation is already running with
+    :func:`is_reload_modified_resources_running`.
+
+    This function being asynchronous, events will be sent to notify the progress of the operation:
+
+    - :class:`substance_painter.event.ReloadResourcesStarted` when the operation starts.
+    - :class:`substance_painter.event.ReloadResourcesEnded` when the operation ends.
+
+    Args:
+        resource_filter (AllResourcesFilter|ResourcesListFilter|ShelvesListFilter): A filter
+            identifying which modified resources to reload.
+
+    Returns:
+        bool: ``True`` if the reload operation has started, ``False`` if it is already running.
+
+    Raises:
+        ServiceNotFoundError: If Substance 3D Painter has not started all its services yet.
+        ValueError: When the given filter is now of a known type.
+        ValueError: When the given filter is ill formed (eg points to unexisting resources). The
+            exception provides one message per problems, as a List[str]
+
+    See also:
+        :func:`is_reload_modified_resources_running`
+        :class:`substance_painter.event.ReloadResourcesStarted`
+        :class:`substance_painter.event.ReloadResourcesEnded`
+        :class:`AllResourcesFilter`
+        :class:`ProjectFilter`
+        :class:`ResourcesListFilter`
+        :class:`ResourcesUsedByProjectFilter`
+        :class:`SessionFilter`
+        :class:`ShelvesListFilter`
+    """
+def is_reload_modified_resources_running() -> bool:
+    """
+    Check if a reload modified resources operation is currently running.
+
+    Raises:
+        ServiceNotFoundError: If Substance 3D Painter has not started all its
+            services yet.
+    """

--- a/substance_painter/stubs/substance_painter-stubs/source.pyi
+++ b/substance_painter/stubs/substance_painter-stubs/source.pyi
@@ -12,51 +12,285 @@ from substance_painter.textureset import ChannelType as ChannelType
 from _substance_painter.source import SourceMode as SourceMode
 
 class FontResolutionMode(Enum):
+    """
+    Members:
+
+    ================= ================================================
+    Name              Description
+    ================= ================================================
+    ``Auto``          Resolution is automatically computed.
+    ``Manual``        Resolution is manually provided.
+    ================= ================================================
+
+    .. warning::
+        Deprecated since 0.3.4, use :class:`~substance_painter.source.ResolutionMode` instead.
+    """
     Auto = ...
     Manual = ...
 
 from _substance_painter.source import HorizontalAlignment as HorizontalAlignment
 from _substance_painter.source import VerticalAlignment as VerticalAlignment
 
-class VectorialResolutionMode(Enum):
+class ResolutionMode(Enum):
+    """
+    Members:
+
+    ================= ==================================================
+    Name              Description
+    ================= ==================================================
+    ``Auto``          Resolution matches the parent context, such as the Texture Set
+                      resolution in a fill layer, or 512 pixels in a brush tool.
+    ``Asset``         Resolution uses the pixel size defined in the vector file.
+                      Not applicable for Font resources.
+    ``Custom``        Resolution is manually provided.
+    ``TextureSet``    Resolution matches the parent textureset's resolution.
+    ``UVTile``        Resolution matches the current uvtile's resolution.
+    ``Document``      Deprecated since 0.3.4, use `Asset` instead.
+    ``Manual``        Deprecated since 0.3.4, use `Custom` instead.
+    ================= ==================================================
+    """
     Auto = ...
+    Asset = ...
+    Custom = ...
+    TextureSet = ...
+    UVTile = ...
     Document = ...
     Manual = ...
-
+VectorialResolutionMode = ResolutionMode
 from _substance_painter.source import CropAreaMode as CropAreaMode
 from _substance_painter.source import AlphaMatte as AlphaMatte
 
-class ActiveChannelsMixin:
+@dataclasses.dataclass
+class ResolutionOverride:
+    """
+    Resolution override parameters.
+
+    :param mode: Control how the resource rendering resolution is driven.
+    :param value: The resolution to use when `mode` is
+        :class:`ResolutionMode.Manual <ResolutionMode>`, as [width, height] in pixels.
+        Values must be a power of 2, in range [128, 4096].
+    :param log2_offset: Log2 resolution boost or reduce, applied on both width and height.
+        Only used if `mode` is set to :class:`ResolutionMode.Auto <ResolutionMode>`.
+    """
+    mode: ResolutionMode
+    value: tuple[int, int]
+    log2_offset: int
+    def __setattr__(self, __name: str, /, __value: dataclasses.Any) -> None: ...  # type: ignore[name-defined]
+
+class _ResolutionOverrideDeprecated:
+    """Helpers to add deprecated properties for retrocompatibility."""
     @property
-    def active_channels(self) -> set[ChannelType]: ...
+    def resolution_mode(self):
+        """
+        :meta private:
+        """
+    @resolution_mode.setter
+    def resolution_mode(self, value) -> None:
+        """
+        :meta private:
+        """
+    @property
+    def resolution_value(self):
+        """
+        :meta private:
+        """
+    @resolution_value.setter
+    def resolution_value(self, value) -> None:
+        """
+        :meta private:
+        """
+
+class ActiveChannelsMixin:
+    """
+    Mixin providing active channels property.
+
+    :meta private:
+    """
+    @property
+    def active_channels(self) -> set[ChannelType]:
+        """
+        The set of active channels of the source.
+
+        :getter: Returns the active channels of the source. To get the list of channels
+            for a given stack, see :meth:`substance_painter.textureset.Stack.all_channels`.
+        :setter: Sets the active channels of the source, channels not listed will be
+            disabled.
+        """
     @active_channels.setter
     def active_channels(self, channels: set[ChannelType]) -> None: ...
 
 class SourceEditorMixin(ActiveChannelsMixin):
+    """
+    Mixin providing all necessary functions to edit sources.
+
+    :meta private:
+    """
     @property
-    def source_mode(self) -> SourceMode: ...
-    def get_source(self, channeltype: ChannelType | None = None) -> Source: ...
-    def set_source(self, channeltype: ChannelType | None, source: ResourceID | Color | layerstack.AnchorPointEffectNode) -> Source: ...  # type: ignore[name-defined]
-    def reset_source(self, channeltype: ChannelType | None = None) -> None: ...
-    def get_material_source(self) -> SourceSubstance | SourceReference: ...
-    def set_material_source(self, source: ResourceID | layerstack.AnchorPointEffectNode) -> SourceSubstance | SourceReference: ...  # type: ignore[name-defined]
-    def reset_material_source(self) -> None: ...
-    def set_sources_from_preset(self, preset: ResourceID) -> None: ...
+    def source_mode(self) -> SourceMode:
+        """
+        The current context in which the source is edited:
+
+        * ``Material``: only one source is used to write to several
+          channels, see :func:`~get_material_source` and :func:`~set_material_source`.
+        * ``Split``: each source write to a single channel, see :func:`~get_source` and
+          :func:`~set_source`.
+        * ``None``: the current context is not multi-channel (ex: a mask),
+          see :func:`~get_source` and :func:`~set_source`.
+
+        For more details, see :ref:`fill_example`.
+
+        :getter: Returns the source mode.
+        """
+    def get_source(self, channeltype: ChannelType | None = None) -> Source:
+        """
+        Get the source for the given channel type.
+
+        :param channeltype: Must be None in mono channel context.
+        :raises EditionContextException: If the `channeltype` is not valid in the current context.
+                See :attr:`active_channels`.
+        :raises RuntimeError: If the source is in :class:`SourceMode.Material <SourceMode>`.
+                See :attr:`source_mode`.
+        :returns: the source at channel type.
+        """
+    def set_source(self, channeltype: ChannelType | None, source: ResourceID | Color | layerstack.AnchorPointEffectNode) -> Source:  # type: ignore[name-defined]
+        """
+        Set the source for the given channel type.
+
+        :param channeltype: Must be None in mono channel context.
+        :param source: the source parameter.
+        :raises EditionContextException: If the `channeltype` is not valid in the current context.
+                See :attr:`active_channels`.
+        :raises ValueError: If the `source` parameter is not valid.
+        :returns: the source at channel type.
+        """
+    def reset_source(self, channeltype: ChannelType | None = None) -> None:
+        """
+        Reset the source at channel type.
+
+        :param channeltype: Must be None in mono channel context.
+        :raises EditionContextException: If the `channeltype` is not valid in the current context.
+                See :attr:`active_channels`.
+        """
+    def get_material_source(self) -> SourceSubstance | SourceReference:
+        """
+        Get the source in material mode.
+
+        :raises RuntimeError: If the source is not in :class:`SourceMode.Material <SourceMode>`.
+                See :attr:`source_mode`.
+        :raises EditionContextException: If the current context in not multi-channel.
+        :returns: the source.
+        """
+    def set_material_source(self, source: ResourceID | layerstack.AnchorPointEffectNode) -> SourceSubstance | SourceReference:  # type: ignore[name-defined]
+        """
+        Set the source in material mode.
+
+        :param source: the source parameter.
+        :raises ValueError: If the `source` parameter is not valid.
+        :raises EditionContextException: If the current context in not multi-channel.
+        :returns: the source.
+        """
+    def reset_material_source(self) -> None:
+        """
+        Reset the source in material mode.
+
+        :raises EditionContextException: If the current context in not multi-channel.
+        """
+    def set_sources_from_preset(self, preset: ResourceID) -> None:
+        """
+        Setup the fill with the given preset.
+
+        :param preset: the resource preset.
+        :raises ValueError: If `preset` is not a valid resource preset.
+        """
 
 class SourceUniformColor(ReadOnlyUid):
-    def get_color(self) -> Color: ...
-    def set_color(self, color: Color) -> None: ...
+    """
+    A class that represents an uniform color source.
+    """
+    def get_color(self) -> Color:
+        """
+        Get the uniform color of the source.
+
+        :returns: The uniform color used by the source.
+        """
+    def set_color(self, color: Color) -> None:
+        """
+        Set the uniform color of the source.
+
+        :param color: The desired uniform color.
+        """
 
 class SourceBitmap(ReadOnlyUid):
+    """
+    A class that represents a bitmap source.
+    """
     @property
-    def resource_id(self) -> ResourceID: ...
-    def get_color_space(self) -> ResourceColorSpace: ...
-    def set_color_space(self, color_space: ResourceColorSpace): ...
-    def reset_color_space(self) -> None: ...
-    def list_available_color_spaces(self) -> list[ResourceColorSpace]: ...
+    def resource_id(self) -> ResourceID:
+        """
+        The current bitmap used by the source.
+
+        :getter: Returns the resource identifier of the bitmap used by the source.
+        """
+    def get_color_space(self) -> ResourceColorSpace:
+        """
+        Return the color space of the bitmap.
+
+        :returns: The current color space.
+
+        See also:
+            :ref:`colormanagement_colorspaces` section.
+        """
+    def set_color_space(self, color_space: ResourceColorSpace):
+        """
+        Override the default color space of the bitmap.
+
+        :param color_space: The color space to set.
+        :raises ValueError: If the given color space is not supported in the current context
+            or by the current color management engine.
+
+        See also:
+            :ref:`colormanagement_colorspaces` section, :func:`list_available_color_spaces`.
+        """
+    def reset_color_space(self) -> None:
+        """
+        Remove any override color space and go back to the default one.
+        """
+    def list_available_color_spaces(self) -> list[ResourceColorSpace]:
+        """
+        Get the list of available color spaces for the bitmap.
+
+        :returns: The list of available color spaces.
+
+        See also:
+            :ref:`colormanagement_colorspaces` section.
+        """
 
 @dataclasses.dataclass
-class SourceFontParams:
+class SourceFontParams(_ResolutionOverrideDeprecated):
+    '''
+    The source font parameters.
+
+    :param text: The text to render.
+    :param auto_size: Automatically adjust size to fit the render resolution.
+    :param size: Manual size of the font, normalized and proportional to the resolution.
+        Value must be positive.
+    :param horizontal_alignment: The horizontal position of the text (left, center, right).
+    :param vertical_alignment: The vertical position of the text (top, middle, bottom).
+    :param color: The text color as RGB values. Values must be in range [0, 1].
+    :param background_color: The RGB background color. Values must be in range [0, 1].
+    :param background_opacity: The background opacity value. Value must be in range [0, 1].
+    :param line_spacing: Distance between lines of text ("leading") relative to the font size.
+    :param character_spacing: The amount of space between adjacent characters relative to
+        the font size. Can be negative to subtract spacing.
+    :param offset: Horizontal and vertical offset of the text. Normalized to the font size.
+    :param resolution: Resolution parameters of the resource.
+    :param resolution_mode: Deprecated since 0.3.4. Use ``mode`` attribute from **resolution**
+        parameter instead.
+    :type resolution_mode: FontResolutionMode
+    :param resolution_value: Deprecated since 0.3.4. Use ``value`` attribute from **resolution**
+        parameter instead.
+    :type resolution_value: Tuple[int, int]
+    '''
     text: str | None
     auto_size: bool
     size: float | None
@@ -68,34 +302,95 @@ class SourceFontParams:
     line_spacing: float
     character_spacing: float
     offset: tuple[float, float]
-    resolution_mode: FontResolutionMode
-    resolution_value: tuple[int, int]
+    resolution: ResolutionOverride
     def __setattr__(self, __name: str, /, __value: dataclasses.Any) -> None: ...  # type: ignore[name-defined]
 
 class SourceFont(ReadOnlyUid):
+    """
+    A class that represents a text source.
+    """
     @property
-    def resource_id(self) -> ResourceID: ...
-    def get_parameters(self) -> SourceFontParams: ...
-    def set_parameters(self, params: SourceFontParams) -> None: ...
+    def resource_id(self) -> ResourceID:
+        """
+        The current font resource of the source.
+
+        :getter: Returns the resource identifier of the font used by the source.
+        """
+    def get_parameters(self) -> SourceFontParams:
+        """
+        Get the source parameters.
+
+        :returns: The source parameters.
+        """
+    def set_parameters(self, params: SourceFontParams) -> None:
+        """
+        Set the source parameters.
+
+        :param params: The source parameters.
+        :raises ValueError: If the parameters requirements are not met,
+            see :class:`SourceFontParams`.
+        """
 
 @dataclasses.dataclass
-class SourceVectorialParams:
+class SourceVectorialParams(_ResolutionOverrideDeprecated):
+    """
+    The source vectorial parameters.
+
+    :param artboard_id: The artboard id, for .ai file.
+    :param scope: The root element of the hierarchy you want to import.
+    :param resolution: Resolution parameters of the resource.
+    :param resolution_mode: Deprecated since 0.3.4. Use ``mode`` attribute from **resolution**
+        parameter instead.
+    :type resolution_mode: ResolutionMode
+    :param resolution_value: Deprecated since 0.3.4. Use ``value`` attribute from **resolution**
+        parameter instead.
+    :type resolution_value: Tuple[int, int]
+    :param crop_area_mode: The crop area mode.
+    :param crop_area_value: The crop area to use when `crop_area_mode` is `CropAreaMode.Manual`,
+        formatted as [left corner x, left corner y, crop area width, crop area height].
+        `width` and `height` values must be positive.
+    :param fit_to_square: Force the crop area to be square.
+    """
     artboard_id: str | None
     scope: str | None
-    resolution_mode: VectorialResolutionMode
-    resolution_value: tuple[int, int]
+    resolution: ResolutionOverride
     crop_area_mode: CropAreaMode
     crop_area_value: tuple[float, float, float, float]
     fit_to_square: bool = ...
     def __setattr__(self, __name: str, /, __value: dataclasses.Any) -> None: ...  # type: ignore[name-defined]
 
 class SourceVectorial(ReadOnlyUid):
+    """
+    A class that represents a vectorial source.
+    """
     @property
-    def resource_id(self) -> ResourceID: ...
-    def get_parameters(self) -> SourceVectorialParams: ...
-    def set_parameters(self, params: SourceVectorialParams) -> None: ...
+    def resource_id(self) -> ResourceID:
+        """
+        The current vectorial resource of the source.
+
+        :getter: Returns the resource identifier of the vectorial used by the source.
+        """
+    def get_parameters(self) -> SourceVectorialParams:
+        """
+        Get the source parameters.
+
+        :returns: The source parameters.
+        """
+    def set_parameters(self, params: SourceVectorialParams) -> None:
+        """
+        Set the source parameters.
+
+        :param params: The source parameters.
+        :raises ValueError: If the parameters requirements are not met,
+            see :class:`SourceVectorialParams`.
+        """
 
 class OutputMappingIterator:
+    """
+    This class implements the iterator interface for class OutputMapping.
+
+    :meta private:
+    """
     keys: Incomplete
     iterator: Incomplete
     def __init__(self, uid) -> None: ...
@@ -103,6 +398,28 @@ class OutputMappingIterator:
     def __next__(self): ...
 
 class OutputMapping(ReadOnlyUid):
+    """
+    This class gives access to the output mapping of a source procedural in a dict-like fashion.
+    See :attr:`~substance_painter.source.SourceSubstance.output_mapping` property.
+
+    Example:
+
+    .. code-block:: python
+
+        import substance_painter as sp
+        mapping = a_substance_source.output_mapping
+        mapping[sp.textureset.ChannelType.BaseColor] = sp.textureset.ChannelType.Specular
+        for channel in mapping:
+            print(mapping[channel])
+
+    See also:
+        For more technical informations, see the official `KeysView ABCs container
+        <https://docs.python.org/3/library/collections.abc.html#collections.abc.KeysView>`_
+        documentation as well as `__getitem__
+        <https://docs.python.org/3/reference/datamodel.html#object.__getitem__>`_ and
+        `__setitem__ <https://docs.python.org/3/reference/datamodel.html#object.__setitem__>`_
+        methods.
+    """
     def __getitem__(self, key: ChannelType) -> ChannelType: ...
     def __setitem__(self, key: ChannelType, value: str) -> None: ...
     def __len__(self) -> int: ...
@@ -110,33 +427,158 @@ class OutputMapping(ReadOnlyUid):
     def __iter__(self) -> OutputMappingIterator: ...
 
 class SourceSubstance(ReadOnlyUid):
+    """
+    A class that represents a procedural source.
+    """
     @property
-    def resource_id(self) -> ResourceID: ...
+    def resource_id(self) -> ResourceID:
+        """
+        The current substance resource of the source.
+
+        :getter: Returns the resource of the source.
+        """
     @property
-    def output_mapping(self) -> OutputMapping: ...
+    def output_mapping(self) -> OutputMapping:
+        """
+        The output mapping property in multiple output context.
+
+        :getter: Returns the output mapping property.
+        :setter: Sets the output mapping property.
+        """
     @property
-    def active_output(self) -> str: ...
+    def active_output(self) -> str:
+        """
+        The active output of the source in single output context.
+
+        :getter: Returns the output identifier.
+        :setter: Sets the output identifier.
+        """
     @active_output.setter
     def active_output(self, identifier: str) -> None: ...
     @property
-    def mask_output(self) -> str: ...
+    def mask_output(self) -> str:
+        """
+        The mask output identifier of the source in multiple output context.
+
+        :getter: Returns the mask output identifier.
+        :setter: Sets the mask output identifier.
+        """
     @mask_output.setter
     def mask_output(self, identifier: str) -> None: ...
     @property
-    def image_inputs(self) -> list[str]: ...
+    def image_inputs(self) -> list[str]:
+        """
+        The list of image inputs identifier from the current graph.
+
+        :getter: Returns the list of image inputs identifier.
+
+        See also:
+            :class:`substance_painter.properties.Property`
+        """
     @property
-    def image_outputs(self) -> list[str]: ...
-    def get_source(self, identifier: str) -> Source: ...
-    def set_source(self, identifier: str, source: ResourceID | Color | layerstack.AnchorPointEffectNode) -> Source: ...  # type: ignore[name-defined]
-    def reset_source(self, identifier: str) -> None: ...
-    def remove_source(self, identifier: str) -> None: ...
-    def get_parameters(self) -> dict[str, PropertyValue]: ...
-    def set_parameters(self, property_values: dict[str, PropertyValue]) -> None: ...
-    def get_properties(self) -> dict[str, Property]: ...
-    def get_preset_list(self) -> list[str]: ...
-    def apply_preset(self, name: str): ...
+    def image_outputs(self) -> list[str]:
+        """
+        The list of image outputs identifier from the current graph.
+
+        :getter: Returns the list of image outputs identifier.
+        """
+    def get_source(self, identifier: str) -> Source:
+        """
+        Get the source for the given input identifier.
+
+        :param identifier: The input identifier.
+        :returns: the source for the input.
+        """
+    def set_source(self, identifier: str, source: ResourceID | Color | layerstack.AnchorPointEffectNode) -> Source:  # type: ignore[name-defined]
+        """
+        Set the source for the given input identifier.
+
+        :param identifier: The input identifier.
+        :param source: The source parameter.
+        :returns: The source for the input.
+        """
+    def reset_source(self, identifier: str) -> None:
+        """
+        Reset the source for the given input identifier.
+
+        :param identifier: The input identifier.
+        """
+    def remove_source(self, identifier: str) -> None:
+        """
+        Remove the source for the given input identifier.
+
+        :param identifier: The input identifier.
+        """
+    def get_parameters(self) -> dict[str, PropertyValue]:
+        """
+        Get source procedural parameters. For each property of the source,
+        the resulting dictionnary holds an entry with the property name as key
+        and the property value as value.
+
+        :returns: The source procedural parameters.
+
+        See also:
+            :func:`substance_painter.source.SourceSubstance.get_properties`
+        """
+    def set_parameters(self, property_values: dict[str, PropertyValue]) -> None:
+        """
+        Set source procedural parameters.
+
+        :param property_values: A dict of properties to be set with their corresponding values.
+
+        Warning:
+            Boolean parameters are treated as integer, if you use `True` or `False` you will get an
+            error message:
+
+            `>>> Bad value for property '<property_name>': expected value of type <int32> but got
+            <bool>`
+        """
+    def get_properties(self) -> dict[str, Property]:
+        """
+        Get source procedural properties.
+
+        :returns: The source procedural properties.
+
+        See also:
+            :class:`substance_painter.properties.Property`
+        """
+    def get_preset_list(self) -> list[str]:
+        """
+        Get the list of all available presets for this source.
+
+        :returns: An array of all preset's names available.
+
+        See also:
+            :func:`substance_painter.source.SourceSubstance.apply_preset`
+        """
+    def apply_preset(self, name: str):
+        """
+        Apply a preset given its name. If no preset is found with this name nothing is done.
+
+        :param name: The name of the preset to apply.
+
+        See also:
+            :func:`substance_painter.source.SourceSubstance.get_preset_list`
+        """
+    @property
+    def resolution(self) -> ResolutionOverride:
+        """
+        The resolution parameters for this substance.
+
+        :getter: Returns the resolution parameters.
+        :setter: Sets the resolution parameters.
+        :raises ValueError: if the source is used in a
+            :class:`substance_painter.layerstack.FilterEffectNode`.
+        """
+    @resolution.setter
+    def resolution(self, value): ...
 
 class ChannelMappingIterator:
+    """
+    This class implements the iterator interface for class ChannelMapping.
+
+    :meta private:
+    """
     keys: Incomplete
     iterator: Incomplete
     def __init__(self, uid) -> None: ...
@@ -144,6 +586,28 @@ class ChannelMappingIterator:
     def __next__(self): ...
 
 class ChannelMapping(ReadOnlyUid):
+    """
+    This class gives access to the active channels of a source reference in a dict-like fashion.
+    See :attr:`~substance_painter.source.SourceReference.channel_mapping` property.
+
+    Example:
+
+    .. code-block:: python
+
+        import substance_painter as sp
+        mapping = some_SourceReference_object.channel_mapping
+        mapping[sp.textureset.ChannelType.BaseColor] = sp.textureset.ChannelType.Specular
+        for channel in mapping:
+            print(mapping[channel])
+
+    See also:
+        For more technical informations, see the official `KeysView ABCs container
+        <https://docs.python.org/3/library/collections.abc.html#collections.abc.KeysView>`_
+        documentation as well as `__getitem__
+        <https://docs.python.org/3/reference/datamodel.html#object.__getitem__>`_ and
+        `__setitem__ <https://docs.python.org/3/reference/datamodel.html#object.__setitem__>`_
+        methods.
+    """
     def __getitem__(self, key: ChannelType) -> ChannelType: ...
     def __setitem__(self, key: ChannelType, value: ChannelType) -> None: ...
     def __len__(self) -> int: ...
@@ -151,18 +615,58 @@ class ChannelMapping(ReadOnlyUid):
     def __iter__(self) -> ChannelMappingIterator: ...
 
 class SourceReference(ReadOnlyUid):
+    """
+    A class that represents an reference to an anchor point.
+    """
     @property
-    def channel_mapping(self) -> ChannelMapping: ...
+    def channel_mapping(self) -> ChannelMapping:
+        """
+        The channels mapping property.
+
+        :getter: Returns the channel mapping property.
+        :raises EditionContextException: If the current context of the reference is not
+                multi-channel.
+        """
     @property
-    def referenced_channel(self) -> ChannelType: ...
+    def referenced_channel(self) -> ChannelType:
+        """
+        The referenced channel of the source.
+
+        :getter: Returns the referenced channel of the source.
+        :setter: Set the referenced channel of the source.
+        :raises EditionContextException: If the current context of the reference is not
+                single-channel or if the context of the target anchor point is not
+                multi-channel.
+        """
     @referenced_channel.setter
     def referenced_channel(self, channeltype: ChannelType) -> None: ...
     @property
-    def anchor(self) -> layerstack.AnchorPointEffectNode: ...  # type: ignore[name-defined]
+    def anchor(self) -> layerstack.AnchorPointEffectNode:  # type: ignore[name-defined]
+        """
+        The anchor used by this source.
+
+        :getter: Returns the anchor used by the source.
+        """
     @property
-    def alpha_matte(self) -> AlphaMatte: ...
+    def alpha_matte(self) -> AlphaMatte:
+        """
+        The alpha matte used by this source.
+
+        :getter: Returns the alpha matte of the source.
+        :setter: Set the alpha matte of the source.
+        """
     @alpha_matte.setter
     def alpha_matte(self, alpha_matte: AlphaMatte): ...
-    def get_levels(self) -> LevelsParams: ...
-    def set_levels(self, params: LevelsParams) -> None: ...
+    def get_levels(self) -> LevelsParams:
+        """
+        Get the parameters used by the levels of this source.
+
+        :returns: The parameters used by the levels of this source.
+        """
+    def set_levels(self, params: LevelsParams) -> None:
+        """
+        Set the parameters used by the levels of this source.
+
+        :param params: The parameters used by the levels of this source.
+        """
 Source = SourceUniformColor | SourceBitmap | SourceVectorial | SourceSubstance | SourceReference | SourceFont

--- a/substance_painter/stubs/substance_painter-stubs/textureset.pyi
+++ b/substance_painter/stubs/substance_painter-stubs/textureset.pyi
@@ -8,65 +8,932 @@ from _substance_painter.textureset import MeshMapUsage as MeshMapUsage
 
 @dataclasses.dataclass
 class Resolution:
+    """
+    Two dimensional resolution.
+
+    For Texture Sets and UV Tiles, there are restrictions. The resolution must
+    be a power of 2, for example 256, 512, 1024, 2048, etc.
+    It must also be within the range of accepted resolutions.
+
+    For UV Tiles, resolution must be square (ie width = height).
+
+    :param width: The width in pixels.
+    :param height: The height in pixels.
+
+    See also:
+        :meth:`TextureSet.get_resolution`,
+        :meth:`TextureSet.set_resolution`,
+        :meth:`UVTile.get_resolution`,
+        :meth:`UVTile.set_resolution`,
+        :func:`set_resolutions`.
+    """
     width: int = ...
     height: int = ...
 
 @dataclasses.dataclass(frozen=True)
 class Channel:
+    '''A `Substance 3D Painter` channel.
+
+    A channel can be one of the predefined types (`BaseColor`, `Specular`, `Roughness`,
+    etc.) or a user defined type (`User0` to `User7`), corresponding to the material.
+    The channel belongs to a stack. The stack can have one or more of them, but it
+    can have only one channel of each :class:`ChannelType`.
+
+
+    Example:
+        ::
+
+            import substance_painter.textureset
+
+            # Get the unnamed stack of "TextureSetName":
+            paintable_stack = substance_painter.textureset.Stack.from_name("TextureSetName")
+
+            # Get the channel "BaseColor" of that stack:
+            base_color_channel = paintable_stack.get_channel(
+                substance_painter.textureset.ChannelType.BaseColor)
+
+            # Print the color format and bit depth of the base color channel:
+            print("The channel format uses {0} {1}.".format(
+                "RGB" if base_color_channel.is_color() else "L",
+                base_color_channel.bit_depth()))
+
+            # Change the format and bit depth of the base color channel:
+            base_color_channel.edit(
+                channel_format = substance_painter.textureset.ChannelFormat.RGB16)
+    '''
     channel_id: int = ...
-    def format(self) -> ChannelFormat: ...
-    def label(self) -> str: ...
-    def is_color(self) -> bool: ...
-    def is_floating(self) -> bool: ...
-    def bit_depth(self) -> int: ...
-    def type(self) -> ChannelType: ...
-    def edit(self, channel_format: ChannelFormat, label: str | None = None) -> None: ...
+    def format(self) -> ChannelFormat:
+        """
+        Get the channel format. The format indicates both if the channel is color
+        or grayscale, its dynamic range, its bits per component, and if the storage
+        is linear or sRGB.
+
+        Returns:
+            ChannelFormat: This channel format.
+        """
+    def label(self) -> str:
+        """
+        Get the user label for User channels (`User0` to `User7`).
+
+        Returns:
+            str: This channel user label. This is the empty string for non User channels.
+
+        See also:
+            :meth:`Channel.type`,
+            :class:`ChannelType`.
+        """
+    def is_color(self) -> bool:
+        """
+        Check if the channel is in color or grayscale format.
+
+        Returns:
+            bool: ``True`` if the channel format is a color format.
+        """
+    def is_floating(self) -> bool:
+        """
+        Check if the channel is in floating point or normalized fixed point format.
+
+        Returns:
+            bool: ``True`` if the channel format is a floating point format.
+        """
+    def bit_depth(self) -> int:
+        """
+        Get the number of bits per component.
+
+        Returns:
+            int: The channel bit depth per component.
+        """
+    def type(self) -> ChannelType:
+        """
+        Get the channel type.
+
+        Returns:
+            ChannelType: This channel type.
+
+        See also:
+            :meth:`Channel.label`.
+        """
+    def edit(self, channel_format: ChannelFormat, label: str | None = None) -> None:
+        """
+        Change the channel format and label.
+
+        Args:
+            channel_format (ChannelFormat): The new texture format of the channel.
+            label (str, optional): Label of the channel in case of User channel as type.
+
+        Raises:
+            ProjectError: If no project is opened.
+            ValueError: If there is no stack labeled ``stack_id`` in this Texture Set.
+            ValueError: If there is no channel of type ``channel_type`` in this Texture Set.
+            ValueError: If a label was provided but ``channel_type`` is not a user type.
+                Standard channel types have fixed labels.
+            ValueError: If the channel is invalid.
+        """
 
 @dataclasses.dataclass(frozen=True)
-class UVTile:
+class _FrozenUVTile:
     u: int
     v: int
-    def get_resolution(self) -> Resolution: ...
-    def set_resolution(self, new_resolution: Resolution): ...
-    def reset_resolution(self) -> None: ...
-    def all_mesh_names(self) -> list[str]: ...
+
+class UVTile(_FrozenUVTile):
+    """
+    A UV Tile coordinates.
+
+    :param u: The U coordinate of the UV Tile.
+    :param v: The V coordinate of the UV Tile.
+
+    See also:
+        :meth:`TextureSet.all_uv_tiles`
+    """
+    @property
+    def name(self) -> str:
+        """
+        The name of the UV Tile.
+
+        UV Tile names must be unique within a Texture Set.
+
+        :type: str
+        :getter: Get the UV Tile name.
+        :setter: Set the UV Tile name.
+        :raises ProjectError: If no project is opened.
+        :raises ServiceNotFoundError: If Substance 3D Painter has not started all its services yet.
+        :raises ValueError: If the UV Tile is invalid.
+        :raises ValueError: If the name of the UV Tile contains reserved characters.
+        :raises ValueError: If the name of the UV Tile is not unique within the Texture Set.
+        """
+    @name.setter
+    def name(self, name: str) -> None: ...
+    @property
+    def description(self) -> str:
+        """
+        The description of the UV Tile.
+
+        :type: str
+        :getter: Get the UV Tile description.
+        :setter: Set the UV Tile description.
+        :raises ProjectError: If no project is opened.
+        :raises ServiceNotFoundError: If Substance 3D Painter has not started all its services yet.
+        :raises ValueError: If the UV Tile is invalid.
+        """
+    @description.setter
+    def description(self, description: str) -> None: ...
+    def get_resolution(self) -> Resolution:
+        """
+        Get the UV Tile resolution.
+
+        Returns:
+            Resolution: The resolution of this UV Tile in pixels.
+
+        Raises:
+            ProjectError: If no project is opened.
+            ServiceNotFoundError: If Substance Painter has not started all its services yet.
+            ValueError: If the UV Tile is invalid.
+
+        Note:
+            The time complexity of this function is linear in the number of UV Tiles in the parent
+            Texture Set. If you need to process multiple UV Tiles, please see
+            ``TextureSet.get_uvtiles_resolution``.
+
+        See also:
+            :meth:`UVTile.set_resolution`
+            :meth:`UVTile.reset_resolution`
+            :meth:`TextureSet.get_uvtiles_resolution`,
+        """
+    def set_resolution(self, new_resolution: Resolution):
+        """
+        Set the resolution of the UV Tile.
+
+        See resolution restrictions: :class:`Resolution`.
+
+        Args:
+            new_resolution (Resolution): The new resolution for this UV Tile.
+
+        Raises:
+            ProjectError: If no project is opened.
+            ServiceNotFoundError: If Substance Painter has not started all its services yet.
+            ValueError: If ``new_resolution`` is not square.
+            ValueError: If ``new_resolution`` is not a valid resolution.
+            ValueError: If the UV Tile is invalid.
+
+        Note:
+            The time complexity of this function is linear in the number of UVTiles in the parent
+            Texture Set. If you need to process multiple UVTiles, please see
+            ``TextureSet.set_uvtiles_resolution``.
+
+        See also:
+            :meth:`UVTile.get_resolution`,
+            :meth:`UVTile.reset_resolution`,
+            :meth:`TextureSet.set_resolution`,
+            :meth:`TextureSet.set_uvtiles_resolution`,
+        """
+    def reset_resolution(self) -> None:
+        """
+        Reset the resolution of the UV Tile to match the parent Texture Set.
+
+        Raises:
+            ProjectError: If no project is opened.
+            ServiceNotFoundError: If Substance Painter has not started all its services yet.
+            ValueError: If the UV Tile is invalid.
+
+        Note:
+            The time complexity of this function is linear in the number of UVTiles in the parent
+            Texture Set. If you need to process multiple UVTiles, please see
+            ``TextureSet.reset_uvtiles_resolution``.
+
+        See also:
+            :meth:`UVTile.get_resolution`,
+            :meth:`UVTile.set_resolution`,
+            :meth:`TextureSet.reset_uvtiles_resolution`,
+        """
+    def all_mesh_names(self) -> list[str]:
+        """
+        Get the list of meshes of the UV Tile.
+
+        Raises:
+            ProjectError: If no project is opened.
+            ServiceNotFoundError: If Substance Painter has not started all its services yet.
+            ValueError: If the UV Tile is invalid.
+
+        See also:
+            :meth:`TextureSet.all_mesh_names`
+        """
 
 @dataclasses.dataclass(frozen=True)
 class Stack:
+    '''
+    A `Substance 3D Painter` paintable stack.
+
+    A stack can contain a number of channels (BaseColor, Specular, Roughness,
+    etc.), that correspond to the material. The stack belongs to a Texture Set,
+    which may contain one or more stacks.
+
+    Typically, only one stack is used and that stack is transparent to the user.
+    Selecting the Texture Set will select its stack. However, a Texture Set can
+    use layered materials with custom shaders, in which case a specific stack
+    needs to be selected.
+
+    If the Texture Set doesn\'t use material layering, you can retrieve its stack
+    as follows:
+    ::
+
+        import substance_painter.textureset
+
+        # Get the unnamed stack of "TextureSetName":
+        paintable_stack = substance_painter.textureset.Stack.from_name("TextureSetName")
+
+        # Alternatively, get the stack from a Texture Set instance:
+        my_texture_set = substance_painter.textureset.TextureSet.from_name("TextureSetName")
+        paintable_stack = my_texture_set.get_stack()
+
+    If the Texture Set `does` use material layering, you can retrieve its stacks
+    as follows:
+    ::
+
+        import substance_painter.textureset
+
+        # Get the stack called "Mask1" from the Texture Set "TextureSetName":
+        paintable_stack = substance_painter.textureset.Stack.from_name("TextureSetName",
+                                                                       "Mask1")
+
+        # Alternatively, get the stack from a Texture Set instance:
+        my_texture_set = substance_painter.textureset.TextureSet.from_name("TextureSetName")
+        paintable_stack = my_texture_set.get_stack("Mask1")
+
+        # Show the name of the stack:
+        print(paintable_stack.name())
+
+
+    It is possible to query, add, remove or edit the channels of a stack:
+    ::
+
+        import substance_painter.textureset
+
+        # Get the unnamed stack of "TextureSetName":
+        paintable_stack = substance_painter.textureset.Stack.from_name("TextureSetName")
+
+        # List all the channels of the "TextureSetName" Texture Set:
+        for k,v in paintable_stack.all_channels().items():
+            print("{0}: {1}".format(k, str(v.format())))
+
+        # Add a scattering channel to the "TextureSetName" Texture Set:
+        paintable_stack.add_channel(substance_painter.textureset.ChannelType.Scattering,
+                                    substance_painter.textureset.ChannelFormat.L8)
+
+        # Query details of the added scattering channel:
+        if paintable_stack.has_channel(substance_painter.textureset.ChannelType.Scattering):
+            channel = paintable_stack.get_channel(
+                substance_painter.textureset.ChannelType.Scattering)
+            print("The Texture Set now has a scattering channel with {0} bits per pixel."
+                .format(channel.bit_depth()))
+
+        # Change the scattering channel to 16 bits inside the "TextureSetName" Texture Set:
+        paintable_stack.edit_channel(
+            channel_type = substance_painter.textureset.ChannelType.Scattering,
+            channel_format = substance_painter.textureset.ChannelFormat.L16)
+
+        # Remove the scattering channel from "TextureSetName":
+        paintable_stack.remove_channel(substance_painter.textureset.ChannelType.Scattering)
+
+    See also:
+        :class:`TextureSet`,
+        `Texture Set documentation`_.
+
+    .. _Texture Set documentation:
+        https://www.adobe.com/go/painter-texture-set
+    '''
     stack_id: int = ...
     @staticmethod
-    def from_name(texture_set_name: str, stack_name: str = ''): ...
-    def name(self) -> str: ...
-    def material(self): ...
-    def all_channels(self) -> dict[ChannelType, Channel]: ...
-    def add_channel(self, channel_type: ChannelType, channel_format: ChannelFormat, label: str | None = None) -> Channel: ...
-    def remove_channel(self, channel_type: ChannelType) -> None: ...
-    def edit_channel(self, channel_type: ChannelType, channel_format: ChannelFormat, label: str | None = None) -> None: ...
-    def has_channel(self, channel_type: ChannelType) -> bool: ...
-    def get_channel(self, channel_type: ChannelType) -> Channel: ...
+    def from_name(texture_set_name: str, stack_name: str = ''):
+        """
+        Get a stack from its name.
+
+        Args:
+            texture_set_name (str): Texture Set name.
+            stack_name (str): Stack name.
+                Leave empty if the Texture Set does not use material layering.
+
+        Note:
+            The Texture Set and stack names are case sensitive.
+
+        Raises:
+            ProjectError: If no project is opened.
+            ServiceNotFoundError: If Substance 3D Painter has not started all its services yet.
+            ValueError: If ``texture_set_name`` is not string.
+            ValueError: If there is no Texture Set with the name ``texture_set_name``.
+            ValueError: If there is no stack with the name ``stack_name``.
+
+        See also:
+                :meth:`TextureSet.all_stacks`,
+                :meth:`TextureSet.get_stack`.
+        """
+    def name(self) -> str:
+        """
+        Get the stack name.
+        A stack name is empty if the Texture Set it belongs to uses material layering.
+
+        Returns:
+            str: The stack name.
+
+        Raises:
+            ProjectError: If no project is opened.
+            ServiceNotFoundError: If Substance 3D Painter has not started all its services yet.
+            ValueError: If the stack is invalid.
+        """
+    def material(self):
+        """
+        Get the Texture Set this stack belongs to.
+
+        Returns:
+            TextureSet: The Texture Set this stack belongs to.
+
+        Raises:
+            ProjectError: If no project is opened.
+            ServiceNotFoundError: If Substance 3D Painter has not started all its services yet.
+            ValueError: If the stack is invalid.
+
+        See also:
+            :class:`TextureSet`,
+            :func:`all_texture_sets`.
+        """
+    def all_channels(self) -> dict[ChannelType, Channel]:
+        """
+        List all the channels of a stack.
+
+        Returns:
+            dict[ChannelType, Channel]: Map of all the channels of the stack.
+
+        Raises:
+            ProjectError: If no project is opened.
+            ServiceNotFoundError: If Substance 3D Painter has not started all its services yet.
+
+        See also:
+            :meth:`Stack.add_channel`,
+            :meth:`Stack.remove_channel`.
+        """
+    def add_channel(self, channel_type: ChannelType, channel_format: ChannelFormat, label: str | None = None) -> Channel:
+        """
+        Add a new channel to a stack.
+
+        Note:
+            `add_channel` is not available with material layering.
+
+        Args:
+            channel_type (ChannelType): The channel type.
+            channel_format (ChannelFormat): The texture format of the new channel.
+            label (str, optional): The label of the channel in case of User channel as type.
+
+        Returns:
+            Channel: The created channel.
+
+        Raises:
+            ProjectError: If no project is opened.
+            ValueError: If a channel of type ``channel_type`` already exists in this Texture Set.
+            ValueError: If a label was provided but ``channel_type`` is not a user type.
+                Standard channel types have fixed labels.
+            ValueError: If the stack is invalid.
+            ValueError: If the Texture Set uses material layering.
+
+        See also:
+            :meth:`Stack.all_channels`,
+            :meth:`Stack.remove_channel`,
+            :meth:`Stack.edit_channel`.
+        """
+    def remove_channel(self, channel_type: ChannelType) -> None:
+        """
+        Remove a channel from a stack.
+
+        Note:
+            `remove_channel` is not available with material layering.
+
+        Args:
+            channel_type (ChannelType): The channel type.
+
+        Raises:
+            ProjectError: If no project is opened.
+            ValueError: If there is no channel of type ``channel_type`` in this Texture Set.
+            ValueError: If the stack is invalid.
+            ValueError: If the Texture Set uses material layering.
+
+        See also:
+            :meth:`Stack.all_channels`,
+            :meth:`Stack.add_channel`,
+            :meth:`Stack.edit_channel`.
+        """
+    def edit_channel(self, channel_type: ChannelType, channel_format: ChannelFormat, label: str | None = None) -> None:
+        """
+        Change the texture format and label of a channel.
+
+        Args:
+            channel_type (ChannelType): The channel type.
+            channel_format (ChannelFormat): The new texture format of the channel.
+            label (str, optional): The label of the channel in case of User channel as type.
+
+        Raises:
+            ProjectError: If no project is opened.
+            ValueError: If there is no stack labeled ``stack_id`` in this Texture Set.
+            ValueError: If there is no channel of type ``channel_type`` in this Texture Set.
+            ValueError: If a label was provided but ``channel_type`` is not a user type.
+                Standard channel types have fixed labels.
+            ValueError: If the stack is invalid.
+
+        See also:
+            :meth:`Stack.add_channel`,
+            :meth:`Stack.remove_channel`.
+        """
+    def has_channel(self, channel_type: ChannelType) -> bool:
+        """
+        Check if a channel exists in a stack.
+
+        Args:
+            channel_type (ChannelType): The channel type.
+
+        Returns:
+            bool: ``True`` if the stack has a channel of the given type, ``False`` otherwise.
+
+        Raises:
+            ProjectError: If no project is opened.
+            ValueError: If the stack is invalid.
+
+        See also:
+            :meth:`Stack.add_channel`,
+            :meth:`Stack.remove_channel`.
+        """
+    def get_channel(self, channel_type: ChannelType) -> Channel:
+        """
+        Get an existing channel from its type.
+
+        Args:
+            channel_type (Channel): The channel type.
+
+        Returns:
+            Channel: The channel.
+
+        Raises:
+            ProjectError: If no project is opened.
+            ServiceNotFoundError: If Substance 3D Painter has not started all its services yet.
+            ValueError: If the channel doesn't exists.
+
+        See also:
+            :meth:`Stack.has_channel`,
+            :meth:`Stack.add_channel`,
+            :meth:`Stack.remove_channel`.
+        """
 
 @dataclasses.dataclass(frozen=True)
-class TextureSet:
+class _FrozenTextureSet:
     material_id: int
-    @staticmethod
-    def from_name(texture_set_name: str): ...
-    def name(self) -> str: ...
-    def is_layered_material(self) -> bool: ...
-    def all_stacks(self) -> list[Stack]: ...
-    def get_stack(self, stack_name: str = '') -> Stack: ...
-    def get_resolution(self) -> Resolution: ...
-    def set_resolution(self, new_resolution: Resolution): ...
-    def has_uv_tiles(self) -> bool: ...
-    def uv_tile(self, u_coord: int, v_coord: int) -> UVTile: ...
-    def all_uv_tiles(self) -> list[UVTile]: ...
-    def get_uvtiles_resolution(self) -> dict[UVTile, Resolution]: ...
-    def set_uvtiles_resolution(self, resolutions: dict[UVTile, Resolution]): ...
-    def reset_uvtiles_resolution(self, uvtiles: list[UVTile]): ...
-    def all_mesh_names(self) -> list[str]: ...
-    def get_mesh_map_resource(self, usage: MeshMapUsage) -> substance_painter.resource.ResourceID | None: ...
-    def set_mesh_map_resource(self, usage: MeshMapUsage, new_mesh_map: substance_painter.resource.ResourceID | None) -> None: ...
 
-def set_resolutions(texturesets: list[TextureSet], new_resolution: Resolution): ...
-def all_texture_sets() -> list[TextureSet]: ...
-def get_active_stack() -> Stack: ...
-def set_active_stack(stack: Stack) -> None: ...
+class TextureSet(_FrozenTextureSet):
+    '''
+    A `Substance 3D Painter` Texture Set. A Texture Set has a resolution and a
+    number of stacks, and can be layered or not.
+    It optionally also has a number of UV Tiles.
+
+    It uses a set of baked Mesh map textures. Each Mesh map has a defined MeshMapUsage.
+
+    If the corresponding material is not layered, the Texture Set has just one
+    stack, which is transparent to the user. If the material is layered, the
+    Texture Set has several stacks.
+
+    Example:
+        ::
+
+            import substance_painter.textureset
+
+            # Get the Texture Set "TextureSetName":
+            my_texture_set = substance_painter.textureset.TextureSet.from_name("TextureSetName")
+
+            # Show the resolution of the Texture Set:
+            resolution = my_texture_set.get_resolution()
+            print("The resolution is {0}x{1}".format(resolution.width, resolution.height))
+
+            # Change the resolution of the Texture Set:
+            my_texture_set.set_resolution(substance_painter.textureset.Resolution(512, 512))
+
+            # Show information about layering:
+            if my_texture_set.is_layered_material():
+                print("{0} is a layered material".format(my_texture_set.name()))
+
+                # Get the stack called "Mask1" from the Texture Set:
+                mask_stack = my_texture_set.get_stack("Mask1")
+
+                # Print "TextureSetName/Mask1":
+                print(mask_stack)
+
+            else:
+                print("{0} is not a layered material".format(my_texture_set.name()))
+
+            # Show information about UV Tiles:
+            if my_texture_set.has_uv_tiles():
+                print("{0} has UV Tiles:".format(my_texture_set.name()))
+                for tile in my_texture_set.all_uv_tiles():
+                    print("Tile {0} {1}".format(tile.u, tile.v))
+
+            # List all the stacks of the Texture Set "TextureSetName":
+            for stack in my_texture_set.all_stacks():
+                print(stack)
+
+            # Query ambiant occlusion Mesh map of the Texture Set "TextureSetName":
+            usage = substance_painter.textureset.MeshMapUsage.AO
+            meshMapResource = my_texture_set.get_mesh_map_resource(usage)
+
+            if meshMapResource is None :
+                print("{0} does not have a Mesh map defined for usage {1}"
+                    .format(my_texture_set.name(), usage))
+            else:
+                print("{0} uses {1} Mesh map for usage {2}"
+                    .format(my_texture_set.name(), meshMapResource, usage))
+
+            # Unset ambiant occlusion Mesh map of the Texture Set "TextureSetName":
+            my_texture_set.set_mesh_map_resource(usage, None)
+
+    See also:
+        :class:`Stack`,
+        :class:`UVTile`,
+        :class:`MeshMapUsage`,
+        `Texture Set documentation`_.
+
+    .. _Texture Set documentation:
+        https://www.adobe.com/go/painter-texture-set
+
+    :param material_id:
+    '''
+    @staticmethod
+    def from_name(texture_set_name: str):
+        """
+        Get the Texture Set from its name.
+
+        Args:
+            texture_set_name (str): The name of the Texture Set.
+
+        Note:
+            The Texture Set name is case sensitive.
+
+        Raises:
+            ProjectError: If no project is opened.
+            ServiceNotFoundError: If Substance 3D Painter has not started all its services yet.
+            TypeError: If ``texture_set_name`` is missing or not a string.
+            ValueError: If ``texture_set_name`` is empty.
+            ValueError: If there is no Texture Set with the name ``texture_set_name``.
+        """
+    @property
+    def original_name(self) -> str:
+        """
+        The original name of the Texture Set, as it was when it was imported.
+
+        :type: str
+        :getter: Get the Texture Set original name.
+        :raises ProjectError: If no project is opened.
+        :raises ServiceNotFoundError: If Substance 3D Painter has not started all its services yet.
+        :raises ValueError: If the Texture Set is invalid.
+        """
+    @property
+    def name(self) -> str:
+        """
+        The name of the Texture Set.
+
+        Texture Set names must be unique.
+
+        :type: str
+        :getter: Get the Texture Set name.
+        :setter: Set the Texture Set name.
+        :raises ProjectError: If no project is opened.
+        :raises ServiceNotFoundError: If Substance 3D Painter has not started all its services yet.
+        :raises ValueError: If the Texture Set is invalid.
+        :raises ValueError: If the name of the Texture Set contains reserved characters.
+        :raises ValueError: If the name of the Texture Set is not unique.
+        """
+    @name.setter
+    def name(self, name: str) -> None: ...
+    @property
+    def description(self) -> str:
+        """
+        The description of the Texture Set.
+
+        :type: str
+        :getter: Get the Texture Set description.
+        :setter: Set the Texture Set description.
+        :raises ProjectError: If no project is opened.
+        :raises ServiceNotFoundError: If Substance 3D Painter has not started all its services yet.
+        :raises ValueError: If the Texture Set is invalid.
+        """
+    @description.setter
+    def description(self, description: str) -> None: ...
+    def is_layered_material(self) -> bool:
+        """
+        Query if this Texture Set uses material layering.
+
+        Returns:
+            bool: ``True`` if the Texture Set uses material layering, ``False`` otherwise.
+
+        Raises:
+            ProjectError: If no project is opened.
+            ServiceNotFoundError: If Substance 3D Painter has not started all its services yet.
+            ValueError: If the Texture Set is invalid.
+        """
+    def all_stacks(self) -> list[Stack]:
+        """
+        List all the stacks from this Texture Set.
+
+        Returns:
+            list[Stack]: All the stacks of this Texture Set.
+
+        Raises:
+            ProjectError: If no project is opened.
+            ServiceNotFoundError: If Substance 3D Painter has not started all its services yet.
+            ValueError: If the Texture Set is invalid.
+
+        See also:
+            :meth:`TextureSet.get_stack`.
+        """
+    def get_stack(self, stack_name: str = '') -> Stack:
+        """
+        Get a stack of this Texture Set from its name.
+
+        Args:
+            stack_name (str): The stack name.
+                Leave empty if the Texture Set does not use material layering.
+
+        Note:
+            The stack name is case sensitive.
+
+        Returns:
+            Stack: The stack.
+
+        Raises:
+            ProjectError: If no project is opened.
+            ServiceNotFoundError: If Substance 3D Painter has not started all its services yet.
+            ValueError: If the Texture Set is invalid.
+
+        See also:
+            :meth:`TextureSet.all_stacks`.
+        """
+    def get_resolution(self) -> Resolution:
+        """
+        Get the Texture Set resolution.
+
+        Returns:
+            Resolution: The resolution of this Texture Set in pixels.
+
+        Raises:
+            ProjectError: If no project is opened.
+            ServiceNotFoundError: If Substance 3D Painter has not started all its services yet.
+            ValueError: If the Texture Set is invalid.
+
+        See also:
+            :meth:`TextureSet.set_resolution`,
+            :meth:`set_resolutions`.
+        """
+    def set_resolution(self, new_resolution: Resolution):
+        '''
+        Set the resolution of the Texture Set.
+
+        See resolution restrictions: :class:`Resolution`.
+
+        Note:
+            For any Texture Set, you can find its accepted resolutions in the
+            "Texture Set Settings" window, in the "Size" menu.
+
+        Args:
+            new_resolution (Resolution): The new resolution for this Texture Set.
+
+        Raises:
+            ProjectError: If no project is opened.
+            ServiceNotFoundError: If Substance 3D Painter has not started all its services yet.
+            ValueError: If ``new_resolution`` is not a valid resolution.
+            ValueError: If the Texture Set is invalid.
+
+        See also:
+            :meth:`TextureSet.get_resolution`,
+            :meth:`set_resolutions`.
+        '''
+    def has_uv_tiles(self) -> bool:
+        """
+        Check if the Texture Set uses the UV Tiles workflow.
+
+        Returns:
+            bool: ``True`` if the Texture Set uses the UV Tiles workflow, ``False`` otherwise.
+
+        Raises:
+            ProjectError: If no project is opened.
+
+        See also:
+            :meth:`all_uv_tiles`
+        """
+    def uv_tile(self, u_coord: int, v_coord: int) -> UVTile:
+        """
+        Get the Texture Set UV Tile at (u, v) coordinates.
+
+        Args:
+            u_coord (int): The u coordinate of the UV Tile.
+            v_coord (int): The v coordinate of the UV Tile.
+
+        Returns:
+            UVTile: The Texture Set UV Tile at (u, v) coordinate.
+
+        Raises:
+            ProjectError: If no project is opened.
+        """
+    def all_uv_tiles(self) -> list[UVTile]:
+        """
+        Get the list of the Texture Set UV Tiles, ordered by U then V coordinates.
+
+        Returns:
+            typing.List[UVTile]: List of the Texture Set UV Tiles, ordered by U then V coordinates.
+
+        Raises:
+            ProjectError: If no project is opened.
+
+        See also:
+            :meth:`has_uv_tiles`
+        """
+    def get_uvtiles_resolution(self) -> dict[UVTile, Resolution]:
+        """
+        Get all UV Tiles that have a different resolution from the Texture Set, associated
+        to their effective resolution.
+
+        Returns:
+            typing.Dict[UVTile, Resolution]: The dictionary of uvtiles and their                associated resolution.
+
+        Raises:
+            ProjectError: If no project is opened.
+
+        See also:
+            :meth:`UVTile.get_resolution`
+        """
+    def set_uvtiles_resolution(self, resolutions: dict[UVTile, Resolution]):
+        """
+        Set the resolution of the given UV Tiles to the associated resolution.
+
+        Args:
+            resolutions (typing.Dict[UVTile, Resolution]): The dictionary of UV Tiles
+                and their associated resolution.
+
+        Raises:
+            ProjectError: If no project is opened.
+
+        See also:
+            :meth:`UVTile.set_resolution`
+        """
+    def reset_uvtiles_resolution(self, uvtiles: list[UVTile]):
+        """
+        Reset the resolution of the given UV Tiles to the parent Texture Set's resolution.
+
+        Args:
+            uvtiles (typing.List[UVTile]): The list of UV Tiles to be reset.
+
+        Raises:
+            ProjectError: If no project is opened.
+
+        See also:
+            :meth:`UVTile.reset_resolution`
+        """
+    def all_mesh_names(self) -> list[str]:
+        """
+        Get the list of meshes of the Texture Set.
+        When using UV Tiles, the result is the union of the mesh names of every UV Tiles.
+
+        Raises:
+            ProjectError: If no project is opened.
+            ServiceNotFoundError: If Substance Painter has not started all its services yet.
+
+        See also:
+            :meth:`UVTile.all_mesh_names`
+        """
+    def get_mesh_map_resource(self, usage: MeshMapUsage) -> substance_painter.resource.ResourceID | None:
+        """
+        Query the Mesh map for the given usage of the Texture Set.
+
+        Args:
+            usage(MeshMapUsage): Which Mesh map usage is queried.
+
+        Returns:
+            ResourceID: The Mesh map resource or None.
+        """
+    def set_mesh_map_resource(self, usage: MeshMapUsage, new_mesh_map: substance_painter.resource.ResourceID | None) -> None:
+        """
+        Replace the Mesh map for the given usage of the Texture Set.
+
+        Args:
+            usage(MeshMapUsage): Which Mesh map usage to replace.
+            new_mesh_map(ResourceID, optional): The new Mesh map or None to unset.
+
+        Raises:
+            ResourceNotFoundError: If the resource ``new_mesh_map`` is not found or is not of type
+                IMAGE.
+            ValueError: If the resource is already used for another Mesh map usage for the
+                Texture Set.
+        """
+
+def set_resolutions(texturesets: list[TextureSet], new_resolution: Resolution):
+    '''
+    Set the same resolution to multiple Texture Sets.
+
+    See resolution restrictions: :class:`Resolution`.
+
+    Note:
+        For any Texture Set, you can find its accepted resolutions in the
+        "Texture Set Settings" window, in the "Size" menu.
+
+    Args:
+        texturesets (list[TextureSet]): The list of Texture Sets to change.
+        new_resolution (Resolution): The new resolution for the Texture Sets.
+
+    Raises:
+        ProjectError: If no project is opened.
+        ServiceNotFoundError: If Substance 3D Painter has not started all its services yet.
+        ValueError: If a Texture Set in ``texturesets`` is invalid.
+        ValueError: If there are duplicated Texture Sets in ``texturesets``.
+        ValueError: If ``new_resolution`` is not a valid resolution.
+
+    See also:
+        :class:`Resolution`,
+        :meth:`TextureSet.get_resolution`,
+        :meth:`TextureSet.set_resolution`.
+    '''
+def all_texture_sets() -> list[TextureSet]:
+    """
+    List all the Texture Sets of the current project.
+
+    Returns:
+        list[TextureSet]: List of all the Texture Sets of this project.
+
+    Raises:
+        ProjectError: If no project is opened.
+        ServiceNotFoundError: If Substance 3D Painter has not started all its services yet.
+
+    See also:
+        :class:`TextureSet`.
+    """
+def get_active_stack() -> Stack:
+    """
+    Get the currently paintable Texture Set stack.
+
+    Returns:
+        Stack: The currently paintable stack.
+
+    Raises:
+        ProjectError: If no project is opened.
+        RuntimeError: If there is no active stack.
+        ServiceNotFoundError: If Substance 3D Painter has not started all its services yet.
+
+    See also:
+        :class:`Stack`,
+        :func:`set_active_stack`.
+    """
+def set_active_stack(stack: Stack) -> None:
+    """
+    Set the Texture Set stack to be currently paintable.
+
+    Args:
+        stack (Stack): The stack to select.
+
+    Raises:
+        ProjectError: If no project is opened.
+        ServiceNotFoundError: If Substance 3D Painter has not started all its services yet.
+        ValueError: If ``stack`` is not a valid Stack.
+
+    See also:
+        :class:`Stack`,
+        :func:`get_active_stack`.
+    """

--- a/substance_painter/stubs/substance_painter-stubs/ui.pyi
+++ b/substance_painter/stubs/substance_painter-stubs/ui.pyi
@@ -5,17 +5,156 @@ from _typeshed import Incomplete
 from _substance_painter.ui import UIMode as UIMode
 from _substance_painter.ui import ApplicationMenu as ApplicationMenu
 
-def show_main_window() -> None: ...
-def get_main_window() -> PySide6.QtWidgets.QMainWindow: ...
-def get_layout(mode: UIMode) -> bytes: ...
-def get_layout_mode(layout: bytes) -> UIMode: ...
-def set_layout(layout: bytes) -> UIMode: ...
-def reset_layout(mode: UIMode): ...
-def add_dock_widget(widget: PySide6.QtWidgets.QWidget, ui_modes: int = ...) -> PySide6.QtWidgets.QDockWidget: ...
-def add_plugins_toolbar_widget(widget: PySide6.QtWidgets.QWidget): ...
-def add_menu(menu: PySide6.QtWidgets.QMenu): ...
-def add_toolbar(title: str, object_name: str, ui_modes: int = ...) -> PySide6.QtWidgets.QToolBar: ...
-def add_action(menu: ApplicationMenu, action: PySide6.QtGui.QAction): ...
-def delete_ui_element(element: PySide6.QtWidgets.QWidget): ...
-def get_current_mode() -> UIMode: ...
-def switch_to_mode(mode: UIMode) -> None: ...
+def show_main_window() -> None:
+    """Show Substance 3D Painter main window in the windowing system and give it the focus.
+
+    Raises:
+        ServiceNotFoundError: If Substance 3D Painter has not started its UI service.
+    """
+def get_main_window() -> PySide6.QtWidgets.QMainWindow:
+    """Get access to Substance 3D Painter main window.
+
+    Returns:
+        PySide6.QtWidgets.QMainWindow: The application main window.
+
+    Raises:
+        ServiceNotFoundError: If Substance 3D Painter has not started its UI service.
+    """
+def get_layout(mode: UIMode) -> bytes:
+    """Get Substance 3D Painter layout state for the given UI mode.
+
+    Args:
+        mode (UIMode): Selected UI mode.
+
+    Returns:
+        bytes: The layout state.
+
+    Raises:
+        ServiceNotFoundError: If Substance 3D Painter has not started its UI service.
+    """
+def get_layout_mode(layout: bytes) -> UIMode:
+    """Get the Substance 3D Painter UI layout mode of a given state.
+
+    Args:
+        layout (bytes): The layout state, obtained with :func:`get_layout`.
+
+    Returns:
+        UIMode: The state associated UI mode.
+
+    Raises:
+        RuntimeError: In case of incorrect layout data.
+        ServiceNotFoundError: If Substance 3D Painter has not started its UI service.
+    """
+def set_layout(layout: bytes) -> UIMode:
+    """Restore a Substance 3D Painter layout state optained with :func:`get_layout`.
+
+    Args:
+        layout (bytes): The layout state to be restored.
+
+    Returns:
+        UIMode: The restored UI mode.
+
+    Raises:
+        RuntimeError: In case of incorrect layout data.
+        ServiceNotFoundError: If Substance 3D Painter has not started its UI service.
+    """
+def reset_layout(mode: UIMode):
+    """Reset Substance 3D Painter layout to default for a selected UI mode.
+
+    Args:
+        mode (UIMode): Selected UI mode.
+
+    Raises:
+        ServiceNotFoundError: If Substance 3D Painter has not started its UI service.
+    """
+def add_dock_widget(widget: PySide6.QtWidgets.QWidget, ui_modes: int = ...) -> PySide6.QtWidgets.QDockWidget:
+    """Add a widget as a QDockWidget to the main window.
+
+    If the widget has a ``windowIcon``, it will be used as a quick button to easily
+    reopen the QDockWidget when closed. If the widget has a unique ``objectName`` it
+    will be used to properly save and restore the dock widget location and geometry.
+
+    Args:
+        widget (PySide6.QtWidgets.QWidget): The widget to be added as a dock widget.
+        ui_modes (int, optional): A combination of `UIMode` flags.
+
+    Returns:
+        PySide6.QtWidgets.QDockWidget: The corresponding dock widget.
+
+    Raises:
+        ServiceNotFoundError: If Substance 3D Painter has not started its UI service.
+    """
+def add_plugins_toolbar_widget(widget: PySide6.QtWidgets.QWidget):
+    """Add a widget to the plugins toolbar.
+
+    Args:
+        widget (PySide6.QtWidgets.QWidget): The widget to be added.
+
+    Raises:
+        ServiceNotFoundError: If Substance 3D Painter has not started its UI service.
+    """
+def add_menu(menu: PySide6.QtWidgets.QMenu):
+    """Add the given menu to the application main window.
+
+    Args:
+        menu (PySide6.QtWidgets.QMenu): The menu to be added.
+
+    Raises:
+        ServiceNotFoundError: If Substance 3D Painter has not started its UI service.
+    """
+def add_toolbar(title: str, object_name: str, ui_modes: int = ...) -> PySide6.QtWidgets.QToolBar:
+    """Create and add a toolbar to the application main window.
+
+    Args:
+        title (str): The title of the toolbar.
+        object_name (str): The toolbar object name. A unique object name is mandatory for proper
+            save and restore of the UI layout.
+        ui_modes (int): A combination of `UIMode` flags.
+
+    Returns:
+        PySide6.QtWidgets.QToolBar: The newly created toolbar.
+
+    Raises:
+        ServiceNotFoundError: If Substance 3D Painter has not started its UI service.
+    """
+def add_action(menu: ApplicationMenu, action: PySide6.QtGui.QAction):
+    """Add the given action to the given application menu.
+
+    This will clear the action tooltip.
+
+    Args:
+        menu (ApplicationMenu): One of the predefined `ApplicationMenu`.
+        action (PySide6.QtGui.QAction): The action to be added.
+
+    Raises:
+        ServiceNotFoundError: If Substance 3D Painter has not started its UI service.
+    """
+def delete_ui_element(element: PySide6.QtWidgets.QWidget):
+    """Delete a UI element.
+
+    The element passed as parameter is deleted. After that, any attempt to call a
+    method on ``element`` will throw an exception.
+
+    Args:
+        element: The UI element to delete.
+    """
+def get_current_mode() -> UIMode:
+    """
+    Get the current UI mode.
+
+    Returns:
+        UIMode: The current UI mode.
+
+    Raises:
+        ServiceNotFoundError: If Substance 3D Painter has not started its UI service.
+    """
+def switch_to_mode(mode: UIMode) -> None:
+    """
+    Switch to some UI mode.
+
+    Args:
+        mode (UIMode): UI mode to switch to.
+
+    Raises:
+        ServiceNotFoundError: If Substance 3D Painter has not started its UI service.
+    """


### PR DESCRIPTION
# Summary

Add `--include-docstrings` to the Substance Painter `stubgen` commands and regenerate the stubs so API docs are available in IDEs.

example:
<img width="742" height="352" alt="image" src="https://github.com/user-attachments/assets/494dd3c8-f1d9-4663-87ec-54e3ac5220ba" />



## Note

While this technically contradicts [PYI021](https://docs.astral.sh/ruff/rules/docstring-in-stub/), I believe docstrings in stubs substantially improve IDE discoverability, and other packages in this repository already include them, for probably a similar reason.
